### PR TITLE
[Steward] LayerZero's Bridge

### DIFF
--- a/foundry.lock
+++ b/foundry.lock
@@ -1,5 +1,5 @@
 {
   "lib/aave-helpers": {
-    "rev": "2f0f37bebb8b79be47911302e8834c7634458875"
+    "rev": "9350321d2ce927d6e07e5486e1d3abf5a55cd707"
   }
 }

--- a/scripts/DeployOFTBridge.s.sol
+++ b/scripts/DeployOFTBridge.s.sol
@@ -23,7 +23,6 @@ import {OFTConstants} from "src/bridges/oft/OFTConstants.sol";
 
 address constant TOKEN_LOGIC = 0x3765A685a401622C060E5D700D9ad89413363a91;
 bytes32 constant SALT = "Aave Treasury OFT Bridge";
-address constant RECEIVER = address(AaveV3Ethereum.COLLECTOR);
 
 contract DeployOFTArbitrum is ArbitrumScript {
   function run() external broadcast {
@@ -31,8 +30,7 @@ contract DeployOFTArbitrum is ArbitrumScript {
       OFTConstants.ARBITRUM_USDT0_OFT, // USDT0 OFT (OUpgradeable)
       TOKEN_LOGIC, // owner
       GovernanceV3Arbitrum.EXECUTOR_LVL_1, // guardian
-      address(AaveV3Arbitrum.COLLECTOR), // collector
-      RECEIVER
+      address(AaveV3Arbitrum.COLLECTOR) // collector
     );
   }
 }
@@ -43,8 +41,7 @@ contract DeployOFTPolygon is PolygonScript {
       OFTConstants.POLYGON_USDT0_OFT, // USDT0 OFT (OUpgradeable)
       TOKEN_LOGIC, // owner
       GovernanceV3Polygon.EXECUTOR_LVL_1, // guardian
-      address(AaveV3Polygon.COLLECTOR), // collector
-      RECEIVER
+      address(AaveV3Polygon.COLLECTOR) // collector
     );
   }
 }
@@ -55,8 +52,7 @@ contract DeployOFTOptimism is OptimismScript {
       OFTConstants.OPTIMISM_USDT0_OFT, // USDT0 OFT (OUpgradeable)
       TOKEN_LOGIC, // owner
       GovernanceV3Optimism.EXECUTOR_LVL_1, // guardian
-      address(AaveV3Optimism.COLLECTOR), // collector
-      RECEIVER
+      address(AaveV3Optimism.COLLECTOR) // collector
     );
   }
 }
@@ -67,8 +63,7 @@ contract DeployOFTPlasma is PlasmaScript {
       OFTConstants.PLASMA_USDT0_OFT, // USDT0 OFT (OUpgradeable)
       TOKEN_LOGIC, // owner
       GovernanceV3Plasma.EXECUTOR_LVL_1, // guardian
-      address(AaveV3Plasma.COLLECTOR), // collector
-      RECEIVER
+      address(AaveV3Plasma.COLLECTOR) // collector
     );
   }
 }

--- a/scripts/DeployOFTBridge.s.sol
+++ b/scripts/DeployOFTBridge.s.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import {GovernanceV3Optimism} from "aave-address-book/GovernanceV3Optimism.sol";
+import {GovernanceV3Polygon} from "aave-address-book/GovernanceV3Polygon.sol";
+import {GovernanceV3Arbitrum} from "aave-address-book/GovernanceV3Arbitrum.sol";
+import {GovernanceV3Plasma} from "aave-address-book/GovernanceV3Plasma.sol";
+import {AaveV3Ethereum} from "aave-address-book/AaveV3Ethereum.sol";
+import {AaveV3Optimism} from "aave-address-book/AaveV3Optimism.sol";
+import {AaveV3Polygon} from "aave-address-book/AaveV3Polygon.sol";
+import {AaveV3Arbitrum} from "aave-address-book/AaveV3Arbitrum.sol";
+import {AaveV3Plasma} from "aave-address-book/AaveV3Plasma.sol";
+import {
+  ArbitrumScript,
+  OptimismScript,
+  PolygonScript,
+  PlasmaScript
+} from "solidity-utils/contracts/utils/ScriptUtils.sol";
+
+import {OFTBridgeSteward} from "src/bridges/oft/OFTBridgeSteward.sol";
+import {OFTConstants} from "src/bridges/oft/OFTConstants.sol";
+
+address constant TOKEN_LOGIC = 0x3765A685a401622C060E5D700D9ad89413363a91;
+bytes32 constant SALT = "Aave Treasury OFT Bridge";
+address constant RECEIVER = address(AaveV3Ethereum.COLLECTOR);
+
+contract DeployOFTArbitrum is ArbitrumScript {
+  function run() external broadcast {
+    new OFTBridgeSteward{salt: SALT}(
+      OFTConstants.ARBITRUM_USDT0_OFT, // USDT0 OFT (OUpgradeable)
+      TOKEN_LOGIC, // owner
+      GovernanceV3Arbitrum.EXECUTOR_LVL_1, // guardian
+      address(AaveV3Arbitrum.COLLECTOR), // collector
+      RECEIVER
+    );
+  }
+}
+
+contract DeployOFTPolygon is PolygonScript {
+  function run() external broadcast {
+    new OFTBridgeSteward{salt: SALT}(
+      OFTConstants.POLYGON_USDT0_OFT, // USDT0 OFT (OUpgradeable)
+      TOKEN_LOGIC, // owner
+      GovernanceV3Polygon.EXECUTOR_LVL_1, // guardian
+      address(AaveV3Polygon.COLLECTOR), // collector
+      RECEIVER
+    );
+  }
+}
+
+contract DeployOFTOptimism is OptimismScript {
+  function run() external broadcast {
+    new OFTBridgeSteward{salt: SALT}(
+      OFTConstants.OPTIMISM_USDT0_OFT, // USDT0 OFT (OUpgradeable)
+      TOKEN_LOGIC, // owner
+      GovernanceV3Optimism.EXECUTOR_LVL_1, // guardian
+      address(AaveV3Optimism.COLLECTOR), // collector
+      RECEIVER
+    );
+  }
+}
+
+contract DeployOFTPlasma is PlasmaScript {
+  function run() external broadcast {
+    new OFTBridgeSteward{salt: SALT}(
+      OFTConstants.PLASMA_USDT0_OFT, // USDT0 OFT (OUpgradeable)
+      TOKEN_LOGIC, // owner
+      GovernanceV3Plasma.EXECUTOR_LVL_1, // guardian
+      address(AaveV3Plasma.COLLECTOR), // collector
+      RECEIVER
+    );
+  }
+}

--- a/src/bridges/oft/OFTBridgeSteward.sol
+++ b/src/bridges/oft/OFTBridgeSteward.sol
@@ -68,7 +68,6 @@ contract OFTBridgeSteward is OwnableWithGuardian, RescuableBase, IOFTBridgeStewa
     if (nativeFee > maxFee) revert MaxFeeExceeded(nativeFee, maxFee);
     if (address(this).balance < nativeFee) revert InsufficientBalance(address(this).balance, nativeFee);
 
-    // Pull pre-approved USDT funds from collector.
     ICollector(COLLECTOR).transfer(IERC20(USDT), address(this), amount);
 
     // Approve OFT to pull USDT and bridge funds to destination chain.

--- a/src/bridges/oft/OFTBridgeSteward.sol
+++ b/src/bridges/oft/OFTBridgeSteward.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.27;
 
 import {ICollector} from "aave-address-book/AaveV3.sol";
+import {AaveV3Ethereum} from "aave-address-book/AaveV3Ethereum.sol";
 import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
 import {OwnableWithGuardian} from "solidity-utils/contracts/access-control/OwnableWithGuardian.sol";
@@ -21,6 +22,9 @@ contract OFTBridgeSteward is OwnableWithGuardian, RescuableBase, IOFTBridgeStewa
   uint32 public constant DESTINATION_EID = OFTConstants.ETHEREUM_EID;
 
   /// @inheritdoc IOFTBridgeSteward
+  address public constant MAINNET_COLLECTOR = address(AaveV3Ethereum.COLLECTOR);
+
+  /// @inheritdoc IOFTBridgeSteward
   address public immutable OFT_USDT;
 
   /// @inheritdoc IOFTBridgeSteward
@@ -32,27 +36,21 @@ contract OFTBridgeSteward is OwnableWithGuardian, RescuableBase, IOFTBridgeStewa
   /// @inheritdoc IOFTBridgeSteward
   address public immutable COLLECTOR;
 
-  /// @inheritdoc IOFTBridgeSteward
-  address public immutable RECEIVER;
-
   /// @param oftUsdt The OFT address for USDT on this chain
   /// @param initialOwner The initial owner of the contract
   /// @param initialGuardian The initial guardian of the contract
   /// @param collector The local Aave Collector that holds the USDT to bridge and receives rescues / LayerZero refunds
-  /// @param receiver The destination address on Ethereum (the mainnet Aave Collector)
-  constructor(address oftUsdt, address initialOwner, address initialGuardian, address collector, address receiver)
+  constructor(address oftUsdt, address initialOwner, address initialGuardian, address collector)
     OwnableWithGuardian(initialOwner, initialGuardian)
   {
     if (oftUsdt == address(0)) revert InvalidZeroAddress();
     if (initialOwner == address(0)) revert InvalidZeroAddress();
     if (initialGuardian == address(0)) revert InvalidZeroAddress();
     if (collector == address(0)) revert InvalidZeroAddress();
-    if (receiver == address(0)) revert InvalidZeroAddress();
 
     OFT_USDT = oftUsdt;
     USDT = IOFT(OFT_USDT).token();
     COLLECTOR = collector;
-    RECEIVER = receiver;
   }
 
   /// @dev Default receive function enabling the contract to accept native tokens for gas fees
@@ -79,7 +77,7 @@ contract OFTBridgeSteward is OwnableWithGuardian, RescuableBase, IOFTBridgeStewa
     IOFT(OFT_USDT).send{value: nativeFee}(sendParam, messagingFee, COLLECTOR);
     IERC20(USDT).forceApprove(OFT_USDT, 0);
 
-    emit Bridge(USDT, DESTINATION_EID, RECEIVER, amount, minAmountLD);
+    emit Bridge(USDT, DESTINATION_EID, MAINNET_COLLECTOR, amount, minAmountLD);
   }
 
   /// @inheritdoc IOFTBridgeSteward
@@ -111,10 +109,10 @@ contract OFTBridgeSteward is OwnableWithGuardian, RescuableBase, IOFTBridgeStewa
   }
 
   /// @notice Helper function to build SendParam for a given amount and minAmountLD
-  function _buildSendParams(uint256 amount, uint256 minAmountLD) internal view returns (SendParam memory) {
+  function _buildSendParams(uint256 amount, uint256 minAmountLD) internal pure returns (SendParam memory) {
     return SendParam({
       dstEid: DESTINATION_EID,
-      to: bytes32(uint256(uint160(RECEIVER))),
+      to: bytes32(uint256(uint160(MAINNET_COLLECTOR))),
       amountLD: amount,
       minAmountLD: minAmountLD,
       extraOptions: new bytes(0),

--- a/src/bridges/oft/OFTBridgeSteward.sol
+++ b/src/bridges/oft/OFTBridgeSteward.sol
@@ -24,6 +24,9 @@ contract OFTBridgeSteward is OwnableWithGuardian, RescuableBase, IAaveOFTBridgeS
   address public immutable OFT_USDT;
 
   /// @inheritdoc IAaveOFTBridgeSteward
+  /// @dev Assumes `IERC20(USDT).decimals() == IOFT(OFT_USDT).sharedDecimals()`. If they ever differ, OFT
+  ///      will truncate the bridged amount to shared decimals on send and the dust will remain on the
+  ///      steward (recoverable via `rescueToken`). For USDT/USDT0 this is 6 == 6.
   address public immutable USDT;
 
   /// @inheritdoc IAaveOFTBridgeSteward

--- a/src/bridges/oft/OFTBridgeSteward.sol
+++ b/src/bridges/oft/OFTBridgeSteward.sol
@@ -7,38 +7,39 @@ import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/Safe
 import {OwnableWithGuardian} from "solidity-utils/contracts/access-control/OwnableWithGuardian.sol";
 import {RescuableBase, IRescuableBase} from "solidity-utils/contracts/utils/RescuableBase.sol";
 
-import {IAaveOFTBridgeSteward} from "./interfaces/IAaveOFTBridgeSteward.sol";
+import {IOFTBridgeSteward} from "./interfaces/IOFTBridgeSteward.sol";
 import {IOFT, SendParam, MessagingFee, OFTReceipt} from "./interfaces/IOFT.sol";
 import {OFTConstants} from "./OFTConstants.sol";
 
 /// @title OFTBridgeSteward
 /// @author @stevyhacker, jubeira (TokenLogic)
 /// @notice Helper contract to bridge USDT using OFT V2 (LayerZero OFT)
-contract OFTBridgeSteward is OwnableWithGuardian, RescuableBase, IAaveOFTBridgeSteward {
+contract OFTBridgeSteward is OwnableWithGuardian, RescuableBase, IOFTBridgeSteward {
   using SafeERC20 for IERC20;
 
-  /// @inheritdoc IAaveOFTBridgeSteward
+  /// @inheritdoc IOFTBridgeSteward
   uint32 public constant DESTINATION_EID = OFTConstants.ETHEREUM_EID;
 
-  /// @inheritdoc IAaveOFTBridgeSteward
+  /// @inheritdoc IOFTBridgeSteward
   address public immutable OFT_USDT;
 
-  /// @inheritdoc IAaveOFTBridgeSteward
+  /// @inheritdoc IOFTBridgeSteward
   /// @dev Assumes `IERC20(USDT).decimals() == IOFT(OFT_USDT).sharedDecimals()`. If they ever differ, OFT
   ///      will truncate the bridged amount to shared decimals on send and the dust will remain on the
   ///      steward (recoverable via `rescueToken`). For USDT/USDT0 this is 6 == 6.
   address public immutable USDT;
 
-  /// @inheritdoc IAaveOFTBridgeSteward
+  /// @inheritdoc IOFTBridgeSteward
   address public immutable COLLECTOR;
 
-  /// @inheritdoc IAaveOFTBridgeSteward
+  /// @inheritdoc IOFTBridgeSteward
   address public immutable RECEIVER;
 
   /// @param oftUsdt The OFT address for USDT on this chain
   /// @param initialOwner The initial owner of the contract
   /// @param initialGuardian The initial guardian of the contract
-  /// @param collector The address to collect fees
+  /// @param collector The local Aave Collector that holds the USDT to bridge and receives rescues / LayerZero refunds
+  /// @param receiver The destination address on Ethereum (the mainnet Aave Collector)
   constructor(address oftUsdt, address initialOwner, address initialGuardian, address collector, address receiver)
     OwnableWithGuardian(initialOwner, initialGuardian)
   {
@@ -57,7 +58,7 @@ contract OFTBridgeSteward is OwnableWithGuardian, RescuableBase, IAaveOFTBridgeS
   /// @dev Default receive function enabling the contract to accept native tokens for gas fees
   receive() external payable {}
 
-  /// @inheritdoc IAaveOFTBridgeSteward
+  /// @inheritdoc IOFTBridgeSteward
   function bridge(uint256 amount, uint256 minAmountLD, uint256 maxFee) external payable onlyOwnerOrGuardian {
     if (amount == 0) revert InvalidZeroAmount();
     if (minAmountLD == 0) revert InvalidZeroAmount();
@@ -81,23 +82,23 @@ contract OFTBridgeSteward is OwnableWithGuardian, RescuableBase, IAaveOFTBridgeS
     emit Bridge(USDT, DESTINATION_EID, RECEIVER, amount, minAmountLD);
   }
 
-  /// @inheritdoc IAaveOFTBridgeSteward
+  /// @inheritdoc IOFTBridgeSteward
   function rescueToken(address token) external onlyOwnerOrGuardian {
     _emergencyTokenTransfer(token, COLLECTOR, type(uint256).max);
   }
 
-  /// @inheritdoc IAaveOFTBridgeSteward
+  /// @inheritdoc IOFTBridgeSteward
   function rescueEth() external onlyOwnerOrGuardian {
     _emergencyEtherTransfer(COLLECTOR, address(this).balance);
   }
 
-  /// @inheritdoc IAaveOFTBridgeSteward
+  /// @inheritdoc IOFTBridgeSteward
   function quoteSendFee(uint256 amount, uint256 minAmountLD) external view returns (uint256) {
     (, MessagingFee memory messagingFee) = _buildSendParamsAndMessagingFee(amount, minAmountLD);
     return messagingFee.nativeFee;
   }
 
-  /// @inheritdoc IAaveOFTBridgeSteward
+  /// @inheritdoc IOFTBridgeSteward
   function quoteAmountReceived(uint256 amount) external view returns (uint256) {
     SendParam memory sendParam = _buildSendParams(amount, 0);
     (,, OFTReceipt memory receipt) = IOFT(OFT_USDT).quoteOFT(sendParam);

--- a/src/bridges/oft/OFTBridgeSteward.sol
+++ b/src/bridges/oft/OFTBridgeSteward.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import {ICollector} from "aave-address-book/AaveV3.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {SafeERC20} from "openzeppelin-contracts/contracts/token/ERC20/utils/SafeERC20.sol";
+import {OwnableWithGuardian} from "solidity-utils/contracts/access-control/OwnableWithGuardian.sol";
+import {RescuableBase, IRescuableBase} from "solidity-utils/contracts/utils/RescuableBase.sol";
+
+import {IAaveOFTBridgeSteward} from "./interfaces/IAaveOFTBridgeSteward.sol";
+import {IOFT, SendParam, MessagingFee, OFTReceipt} from "./interfaces/IOFT.sol";
+import {OFTConstants} from "./OFTConstants.sol";
+
+/// @title OFTBridgeSteward
+/// @author @stevyhacker, jubeira (TokenLogic)
+/// @notice Helper contract to bridge USDT using OFT V2 (LayerZero OFT)
+contract OFTBridgeSteward is OwnableWithGuardian, RescuableBase, IAaveOFTBridgeSteward {
+  using SafeERC20 for IERC20;
+
+  /// @inheritdoc IAaveOFTBridgeSteward
+  uint32 public constant DESTINATION_EID = OFTConstants.ETHEREUM_EID;
+
+  /// @inheritdoc IAaveOFTBridgeSteward
+  address public immutable OFT_USDT;
+
+  /// @inheritdoc IAaveOFTBridgeSteward
+  address public immutable USDT;
+
+  /// @inheritdoc IAaveOFTBridgeSteward
+  address public immutable COLLECTOR;
+
+  /// @inheritdoc IAaveOFTBridgeSteward
+  address public immutable RECEIVER;
+
+  /// @param oftUsdt The OFT address for USDT on this chain
+  /// @param initialOwner The initial owner of the contract
+  /// @param initialGuardian The initial guardian of the contract
+  /// @param collector The address to collect fees
+  constructor(address oftUsdt, address initialOwner, address initialGuardian, address collector, address receiver)
+    OwnableWithGuardian(initialOwner, initialGuardian)
+  {
+    if (oftUsdt == address(0)) revert InvalidZeroAddress();
+    if (initialOwner == address(0)) revert InvalidZeroAddress();
+    if (initialGuardian == address(0)) revert InvalidZeroAddress();
+    if (collector == address(0)) revert InvalidZeroAddress();
+    if (receiver == address(0)) revert InvalidZeroAddress();
+
+    OFT_USDT = oftUsdt;
+    USDT = IOFT(OFT_USDT).token();
+    COLLECTOR = collector;
+    RECEIVER = receiver;
+  }
+
+  /// @dev Default receive function enabling the contract to accept native tokens for gas fees
+  receive() external payable {}
+
+  /// @inheritdoc IAaveOFTBridgeSteward
+  function bridge(uint256 amount, uint256 minAmountLD, uint256 maxFee) external payable onlyOwnerOrGuardian {
+    if (amount == 0) revert InvalidZeroAmount();
+    if (minAmountLD == 0) revert InvalidZeroAmount();
+
+    (SendParam memory sendParam, MessagingFee memory messagingFee) =
+      _buildSendParamsAndMessagingFee(amount, minAmountLD);
+    uint256 nativeFee = messagingFee.nativeFee;
+
+    if (nativeFee > maxFee) revert MaxFeeExceeded(nativeFee, maxFee);
+    if (address(this).balance < nativeFee) revert InsufficientBalance(address(this).balance, nativeFee);
+
+    // Pull pre-approved USDT funds from collector.
+    ICollector(COLLECTOR).transfer(IERC20(USDT), address(this), amount);
+
+    // Approve OFT to pull USDT and bridge funds to destination chain.
+    // Reset approvals to 0 to ensure no dangling approval persists afterwards for any reason.
+    IERC20(USDT).forceApprove(OFT_USDT, amount);
+    IOFT(OFT_USDT).send{value: nativeFee}(sendParam, messagingFee, COLLECTOR);
+    IERC20(USDT).forceApprove(OFT_USDT, 0);
+
+    emit Bridge(USDT, DESTINATION_EID, RECEIVER, amount, minAmountLD);
+  }
+
+  /// @inheritdoc IAaveOFTBridgeSteward
+  function rescueToken(address token) external onlyOwnerOrGuardian {
+    _emergencyTokenTransfer(token, COLLECTOR, type(uint256).max);
+  }
+
+  /// @inheritdoc IAaveOFTBridgeSteward
+  function rescueEth() external onlyOwnerOrGuardian {
+    _emergencyEtherTransfer(COLLECTOR, address(this).balance);
+  }
+
+  /// @inheritdoc IAaveOFTBridgeSteward
+  function quoteSendFee(uint256 amount, uint256 minAmountLD) external view returns (uint256) {
+    (, MessagingFee memory messagingFee) = _buildSendParamsAndMessagingFee(amount, minAmountLD);
+    return messagingFee.nativeFee;
+  }
+
+  /// @inheritdoc IAaveOFTBridgeSteward
+  function quoteAmountReceived(uint256 amount) external view returns (uint256) {
+    SendParam memory sendParam = _buildSendParams(amount, 0);
+    (,, OFTReceipt memory receipt) = IOFT(OFT_USDT).quoteOFT(sendParam);
+    return receipt.amountReceivedLD;
+  }
+
+  /// @inheritdoc IRescuableBase
+  function maxRescue(address token) public view override(RescuableBase) returns (uint256) {
+    return IERC20(token).balanceOf(address(this));
+  }
+
+  /// @notice Helper function to build SendParam for a given amount and minAmountLD
+  function _buildSendParams(uint256 amount, uint256 minAmountLD) internal view returns (SendParam memory) {
+    return SendParam({
+      dstEid: DESTINATION_EID,
+      to: bytes32(uint256(uint160(RECEIVER))),
+      amountLD: amount,
+      minAmountLD: minAmountLD,
+      extraOptions: new bytes(0),
+      composeMsg: new bytes(0),
+      oftCmd: new bytes(0)
+    });
+  }
+
+  /// @notice Helper function to build SendParam and MessagingFee for a given amount and minAmountLD
+  function _buildSendParamsAndMessagingFee(uint256 amount, uint256 minAmountLD)
+    internal
+    view
+    returns (SendParam memory, MessagingFee memory)
+  {
+    SendParam memory sendParam = _buildSendParams(amount, minAmountLD);
+    MessagingFee memory messagingFee = IOFT(OFT_USDT).quoteSend(sendParam, false);
+
+    return (sendParam, messagingFee);
+  }
+}

--- a/src/bridges/oft/OFTConstants.sol
+++ b/src/bridges/oft/OFTConstants.sol
@@ -15,9 +15,9 @@ library OFTConstants {
   uint32 internal constant INK_EID = 30339;
   uint32 internal constant PLASMA_EID = 30383;
 
-  // USDT0 OFT Contracts - These are the contracts to call send() on for bridging
-  // On Ethereum: OAdapterUpgradeable (locks USDT, sends LayerZero message)
-  // On other chains: OUpgradeable (burns/mints USDT0)
+  // USDT0 OFT contracts. The steward calls `send()` on the OFT for the chain it's deployed on.
+  // Protocol context: on Ethereum the OFT is OAdapterUpgradeable (locks USDT); on other chains it's
+  // OUpgradeable (burns/mints USDT0). The steward is only deployed on the non-Ethereum side.
 
   /// @dev https://etherscan.io/address/0x6C96dE32CEa08842dcc4058c14d3aaAD7Fa41dee
   address internal constant ETHEREUM_USDT0_OFT = 0x6C96dE32CEa08842dcc4058c14d3aaAD7Fa41dee;
@@ -37,9 +37,9 @@ library OFTConstants {
   /// @dev https://plasmascan.to/address/0x02ca37966753bDdDf11216B73B16C1dE756A7CF9
   address internal constant PLASMA_USDT0_OFT = 0x02ca37966753bDdDf11216B73B16C1dE756A7CF9;
 
-  // USDT/USDT0 Token addresses (the actual ERC20 tokens users hold)
-  // On Ethereum: Native USDT (approve to OAdapterUpgradeable before bridging)
-  // On other chains: USDT0 token (TetherTokenOFTExtension or equivalent)
+  // USDT / USDT0 ERC20 token addresses. On Ethereum this is native USDT; on other chains it's the
+  // USDT0 token (TetherTokenOFTExtension or equivalent). The steward reads this from `IOFT.token()`
+  // at construction; these constants are kept here for off-chain tooling and tests.
 
   /// @dev https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7
   address internal constant ETHEREUM_USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;

--- a/src/bridges/oft/OFTConstants.sol
+++ b/src/bridges/oft/OFTConstants.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title OFT Constants
+/// @notice Constants for USDT0 OFT bridge integration via LayerZero V2
+/// @dev USDT0 supported chains: Ethereum, Arbitrum, Polygon, Optimism, Ink, Plasma
+///      NOT supported: Avalanche, Base (no USDT0 deployment)
+/// @dev Addresses from https://docs.usdt0.to/technical-documentation/developer/usdt0-deployments
+library OFTConstants {
+  // LayerZero V2 Endpoint IDs
+  uint32 internal constant ETHEREUM_EID = 30101;
+  uint32 internal constant POLYGON_EID = 30109;
+  uint32 internal constant ARBITRUM_EID = 30110;
+  uint32 internal constant OPTIMISM_EID = 30111;
+  uint32 internal constant INK_EID = 30339;
+  uint32 internal constant PLASMA_EID = 30383;
+
+  // USDT0 OFT Contracts - These are the contracts to call send() on for bridging
+  // On Ethereum: OAdapterUpgradeable (locks USDT, sends LayerZero message)
+  // On other chains: OUpgradeable (burns/mints USDT0)
+
+  /// @dev https://etherscan.io/address/0x6C96dE32CEa08842dcc4058c14d3aaAD7Fa41dee
+  address internal constant ETHEREUM_USDT0_OFT = 0x6C96dE32CEa08842dcc4058c14d3aaAD7Fa41dee;
+
+  /// @dev https://arbiscan.io/address/0x14E4A1B13bf7F943c8ff7C51fb60FA964A298D92
+  address internal constant ARBITRUM_USDT0_OFT = 0x14E4A1B13bf7F943c8ff7C51fb60FA964A298D92;
+
+  /// @dev https://polygonscan.com/address/0x6BA10300f0DC58B7a1e4c0e41f5daBb7D7829e13
+  address internal constant POLYGON_USDT0_OFT = 0x6BA10300f0DC58B7a1e4c0e41f5daBb7D7829e13;
+
+  /// @dev https://optimistic.etherscan.io/address/0xF03b4d9AC1D5d1E7c4cEf54C2A313b9fe051A0aD
+  address internal constant OPTIMISM_USDT0_OFT = 0xF03b4d9AC1D5d1E7c4cEf54C2A313b9fe051A0aD;
+
+  /// @dev https://explorer.inkonchain.com/address/0x0200C29006150606B650577BBE7B6248F58470c1
+  address internal constant INK_USDT0_OFT = 0x0200C29006150606B650577BBE7B6248F58470c1;
+
+  /// @dev https://plasmascan.to/address/0x02ca37966753bDdDf11216B73B16C1dE756A7CF9
+  address internal constant PLASMA_USDT0_OFT = 0x02ca37966753bDdDf11216B73B16C1dE756A7CF9;
+
+  // USDT/USDT0 Token addresses (the actual ERC20 tokens users hold)
+  // On Ethereum: Native USDT (approve to OAdapterUpgradeable before bridging)
+  // On other chains: USDT0 token (TetherTokenOFTExtension or equivalent)
+
+  /// @dev https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7
+  address internal constant ETHEREUM_USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+
+  /// @dev https://arbiscan.io/address/0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9
+  address internal constant ARBITRUM_USDT = 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9;
+
+  /// @dev https://polygonscan.com/address/0xc2132D05D31c914a87C6611C10748AEb04B58e8F
+  address internal constant POLYGON_USDT = 0xc2132D05D31c914a87C6611C10748AEb04B58e8F;
+
+  /// @dev https://optimistic.etherscan.io/address/0x01bFF41798a0BcF287b996046Ca68b395DbC1071
+  address internal constant OPTIMISM_USDT = 0x01bFF41798a0BcF287b996046Ca68b395DbC1071;
+
+  /// @dev https://explorer.inkonchain.com/address/0x0200C29006150606B650577BBE7B6248F58470c1
+  address internal constant INK_USDT = 0x0200C29006150606B650577BBE7B6248F58470c1;
+
+  /// @dev https://plasmascan.to/address/0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb
+  address internal constant PLASMA_USDT = 0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb;
+}

--- a/src/bridges/oft/README.md
+++ b/src/bridges/oft/README.md
@@ -1,0 +1,136 @@
+# AaveOFTBridge
+
+The AaveOFTBridge is a contract to facilitate moving USDT between networks using USDT0 OFT (Omnichain Fungible Token) via LayerZero V2. This provides seamless, 1:1 cross-chain USDT transfers with no slippage.
+
+## How USDT0 Works
+
+USDT0 is Tether's official cross-chain solution using LayerZero's OFT standard. It enables unified USDT liquidity across chains without wrapped tokens.
+
+### Architecture
+
+- **On Ethereum**: Uses `OAdapterUpgradeable` which locks native USDT and sends LayerZero message
+- **On Other Chains**: Uses `OUpgradeable` which mints/burns USDT0
+
+### Key Benefits
+
+- **No Slippage**: 1:1 lock/mint mechanism (unlike liquidity pool bridges)
+- **Unified Liquidity**: All USDT0 is backed 1:1 by USDT on Ethereum
+- **Dual DVN Security**: Verified by both LayerZero DVN and USDT0 DVN
+
+## Functions
+
+### `bridge()`
+
+Bridges USDT to a destination chain. The steward pulls USDT from the Aave Collector via `ICollector.transfer()`, so it must have the Collector `FUNDS_ADMIN` role. The quoted LayerZero messaging fee should be supplied as native token value with the `bridge()` call.
+
+### `quoteBridge()`
+
+Returns the native token fee required for bridging. Call this before `bridge()` to know how much native token value to send with the transaction.
+
+### `quoteOFT()`
+
+Returns the expected amount to be received on the destination chain. Use this value as `minAmountLD` in the `bridge()` call.
+
+For USDT0 OFT transfers, this should return the same amount (1:1, no slippage).
+
+## Usage Pattern
+
+```solidity
+// 1. Quote the expected received amount
+uint256 expectedReceived = bridge.quoteOFT(dstEid, amount, receiver);
+
+// 2. Quote the native fee
+uint256 fee = bridge.quoteBridge(dstEid, amount, receiver, expectedReceived);
+
+// 3. Grant the steward the Collector FUNDS_ADMIN role
+IAccessControl(address(collector)).grantRole(
+    ICollector(address(collector)).FUNDS_ADMIN_ROLE(),
+    address(bridge)
+);
+
+// 4. Execute the bridge, sending the quoted native fee
+bridge.bridge{value: fee}(dstEid, amount, receiver, expectedReceived, fee);
+```
+
+## Permissions
+
+The contract implements `OwnableWithGuardian` for permissioned functions. The owner should be the respective network's Level 1 Executor (Governance), and the guardian should be a trusted operations role.
+
+The steward must also be granted the Collector `FUNDS_ADMIN` role so it can call `ICollector.transfer()`.
+
+The owner or guardian can:
+
+- Call `bridge()` to initiate transfers
+- Call rescue functions to return assets to the Collector
+
+Only the owner can:
+
+- Update allowed receivers
+- Transfer ownership
+
+## Security Considerations
+
+- The contract inherits from `RescuableBase`, exposing rescue hooks used by the steward's rescue functions
+- Slippage protection via `minAmountLD` parameter prevents receiving less than expected
+- The `quoteOFT()` function should be called immediately before bridging to get accurate amounts
+- Only the owner or guardian can execute bridges, and only to explicitly allowed receivers
+
+## Retry Mechanism
+
+LayerZero includes a retry mechanism to handle transactions which fail to execute on the destination chain.
+
+Because LayerZero separates the verification of a message from its execution, if a message fails to execute, it can be retried without having to resend it from the origin chain. This is possible because the message has already been confirmed by the DVNs as a valid message packet, meaning execution can be retried at any time, by anyone.
+
+### How to Retry
+
+To retry a failed message:
+
+1. **LayerZero Scan Interface**: Use the [LayerZero Scan](https://layerzeroscan.com/) UI to locate and retry the failed message
+2. **Direct Contract Call**: Call the `lzReceive` function directly on the Endpoint contract
+
+For more details, see the [LayerZero debugging documentation](https://docs.layerzero.network/v2/developers/evm/troubleshooting/debugging-messages#retry-message).
+
+## Supported Chains
+
+USDT0 is currently deployed on the following chains:
+
+### Endpoint IDs and OFT Contracts
+
+| Chain    | Endpoint ID | USDT0 OFT Contract                         | Notes                            |
+| -------- | ----------- | ------------------------------------------ | -------------------------------- |
+| Ethereum | 30101       | 0x6C96dE32CEa08842dcc4058c14d3aaAD7Fa41dee | OAdapterUpgradeable (locks USDT) |
+| Arbitrum | 30110       | 0x14E4A1B13bf7F943c8ff7C51fb60FA964A298D92 | OUpgradeable                     |
+| Polygon  | 30109       | 0x6BA10300f0DC58B7a1e4c0e41f5daBb7D7829e13 | OUpgradeable                     |
+| Optimism | 30111       | 0xF03b4d9AC1D5d1E7c4cEf54C2A313b9fe051A0aD | OUpgradeable                     |
+| Ink      | 30339       | 0x0200C29006150606B650577BBE7B6248F58470c1 | OUpgradeable                     |
+| Plasma   | 30383       | 0x02ca37966753bDdDf11216B73B16C1dE756A7CF9 | OUpgradeable                     |
+
+### USDT Token Addresses
+
+| Chain    | USDT/USDT0 Token                           |
+| -------- | ------------------------------------------ |
+| Ethereum | 0xdAC17F958D2ee523a2206206994597C13D831ec7 |
+| Arbitrum | 0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9 |
+| Polygon  | 0xc2132D05D31c914a87C6611C10748AEb04B58e8F |
+| Optimism | 0x01bFF41798a0BcF287b996046Ca68b395DbC1071 |
+| Ink      | 0x0200C29006150606B650577BBE7B6248F58470c1 |
+| Plasma   | 0xB8CE59FC3717ada4C02eaDF9682A9e934F625ebb |
+
+### Not Supported
+
+| Chain     | Reason              |
+| --------- | ------------------- |
+| Avalanche | No USDT0 deployment |
+| Base      | No USDT0 deployment |
+
+## Known Limitations
+
+1. **USDT0 Only**: Only transfers within the USDT0 system are supported.
+
+2. **LayerZero Fees**: A small native token fee is required for the LayerZero messaging. Use `quoteBridge()` to get the exact fee.
+
+## References
+
+- [USDT0 Documentation](https://docs.usdt0.to/)
+- [USDT0 Deployments](https://docs.usdt0.to/technical-documentation/developer/usdt0-deployments)
+- [LayerZero V2 OFT Standard](https://docs.layerzero.network/v2/developers/evm/oft/native-transfer)

--- a/src/bridges/oft/README.md
+++ b/src/bridges/oft/README.md
@@ -83,7 +83,7 @@ There is no allow-list of receivers: `MAINNET_COLLECTOR` is a constant in the co
 ## Security Considerations
 
 - **Slippage protection:** `minAmountLD` enforces the floor for tokens received on Ethereum. Quote `quoteAmountReceived` immediately before sending.
-- **Fee protection:** `maxFee` caps the LayerZero native fee, avoiding open-ended drains if quoting and execution land in different blocks.
+- **Fee protection:** The native fee returned by `quoteSendFee` is a *quote* and can drift between the off-chain quote and on-chain execution — LayerZero's executor uses oracle price feeds for destination gas that refresh periodically (typically on the order of minutes), and DVN fees can also shift. The steward re-quotes inside `bridge` immediately before `IOFT.send` and pays whatever the live fee is, drawing from its own balance. `maxFee` is the caller-supplied ceiling: if the live fee exceeds it the call reverts with `MaxFeeExceeded`, so the steward can never be drained beyond `maxFee` per call. Operational guidance: size `maxFee` as `quoteSendFee * (1 + buffer)` (e.g. `1.1x`); if a call reverts with `MaxFeeExceeded`, re-quote and retry.
 - **Approval hygiene:** The steward `forceApprove`s the OFT for exactly `amount`, then resets to `0` after `send`, so no allowance is left dangling.
 - **Refund routing:** LayerZero's refund recipient is hard-coded to the local `COLLECTOR`, so excess native fee goes back to Aave directly.
 - **Rescue path:** Inherits `RescuableBase`; `maxRescue` returns the steward's full token balance, allowing complete sweep.
@@ -139,7 +139,7 @@ The steward is deployed on each *source* chain. Deployment scripts live in [`scr
 
 1. **Destination is fixed to Ethereum mainnet.** A new contract deployment is required to bridge to any other chain.
 2. **USDT0 only.** Only USDT transfers within the USDT0 system are supported.
-3. **LayerZero native fee.** A small native-token fee is required for messaging. Quote it with `quoteSendFee` before each call.
+3. **LayerZero native fee.** A small native-token fee is required for messaging. Quote it with `quoteSendFee` before each call. The quote can drift between off-chain quote-time and on-chain execution; see **Fee protection** above for how `maxFee` bounds the exposure.
 
 ## References
 

--- a/src/bridges/oft/README.md
+++ b/src/bridges/oft/README.md
@@ -67,7 +67,7 @@ bridge.bridge{value: fee}(amount, expectedReceived, fee);
 
 The contract uses `OwnableWithGuardian`. The owner should be the local network's Level 1 Executor (Aave Governance); the guardian is a trusted ops role.
 
-The steward must also hold the local Collector `FUNDS_ADMIN` role so it can call `ICollector.transfer`.
+The steward must also hold the local Collector `FUNDS_ADMIN` role so it can call `ICollector.transfer`. Note that this role is broader than what `bridge()` actually exercises — it grants the steward the ability to move *any* token from the Collector to *any* address. A bug or future extension to the steward could in principle exfiltrate other Collector funds, so the role grant is a trust assumption that should be considered when reviewing changes to the steward.
 
 The owner or guardian can:
 

--- a/src/bridges/oft/README.md
+++ b/src/bridges/oft/README.md
@@ -2,7 +2,7 @@
 
 `OFTBridgeSteward` is an Aave Steward that bridges USDT from a non-Ethereum chain to the Ethereum mainnet Collector using USDT0 OFT (Omnichain Fungible Token) over LayerZero V2. The transfer is 1:1 with no slippage.
 
-The steward is unidirectional: every deployed instance bridges *to* Ethereum mainnet. The destination endpoint and receiver are immutable, set at construction time (see `DESTINATION_EID` and `RECEIVER`).
+The steward is unidirectional: every deployed instance bridges *to* Ethereum mainnet. The destination endpoint and receiver address are immutable, set in the contract's code (see `DESTINATION_EID` and `MAINNET_COLLECTOR`).
 
 ## How USDT0 Works
 
@@ -23,7 +23,7 @@ USDT0 is Tether's official cross-chain solution using LayerZero's OFT standard. 
 
 ### `bridge(uint256 amount, uint256 minAmountLD, uint256 maxFee)`
 
-Bridges `amount` USDT to the immutable `RECEIVER` on Ethereum (`DESTINATION_EID`). Restricted to owner or guardian.
+Bridges `amount` USDT to the immutable `MAINNET_COLLECTOR` on Ethereum (`DESTINATION_EID`). Restricted to owner or guardian.
 
 - The steward pulls `amount` USDT from the local Collector via `ICollector.transfer`, so it must hold the Collector `FUNDS_ADMIN` role.
 - The native LayerZero fee is paid from the steward's own balance. It can be either pre-funded (use `receive()` or `transfer`) or supplied as `msg.value` on the same call — both add to `address(this).balance`, which is what the contract checks.
@@ -37,7 +37,7 @@ Returns the native-token fee LayerZero will charge for `bridge(amount, minAmount
 
 ### `quoteAmountReceived(uint256 amount) returns (uint256)`
 
-Returns the amount of USDT the receiver will get on Ethereum for an `amount` send (after any OFT-level dust truncation). For USDT0 this equals `amount` (no slippage), but always re-quote on-chain rather than assume.
+Returns the amount of USDT the Mainnet Collector will get for an `amount` send (after any OFT-level dust truncation). For USDT0 this equals `amount` (no slippage), but always re-quote on-chain rather than assume.
 
 ### `rescueToken(address token)` / `rescueEth()`
 
@@ -78,7 +78,7 @@ Only the owner can:
 
 - Transfer ownership.
 
-There is no allow-list of receivers: `RECEIVER` is set at deployment time and immutable.
+There is no allow-list of receivers: `MAINNET_COLLECTOR` is a constant in the contract's code.
 
 ## Security Considerations
 
@@ -87,7 +87,7 @@ There is no allow-list of receivers: `RECEIVER` is set at deployment time and im
 - **Approval hygiene:** The steward `forceApprove`s the OFT for exactly `amount`, then resets to `0` after `send`, so no allowance is left dangling.
 - **Refund routing:** LayerZero's refund recipient is hard-coded to the local `COLLECTOR`, so excess native fee goes back to Aave directly.
 - **Rescue path:** Inherits `RescuableBase`; `maxRescue` returns the steward's full token balance, allowing complete sweep.
-- **Fixed destination/receiver:** `DESTINATION_EID` (Ethereum mainnet) and `RECEIVER` are immutable, removing destination-spoofing surface.
+- **Fixed destination/receiver:** `DESTINATION_EID` (Ethereum mainnet) and `MAINNET_COLLECTOR` are constants, removing destination-spoofing surface.
 
 ## Retry Mechanism
 

--- a/src/bridges/oft/README.md
+++ b/src/bridges/oft/README.md
@@ -1,6 +1,8 @@
-# AaveOFTBridge
+# OFTBridgeSteward
 
-The AaveOFTBridge is a contract to facilitate moving USDT between networks using USDT0 OFT (Omnichain Fungible Token) via LayerZero V2. This provides seamless, 1:1 cross-chain USDT transfers with no slippage.
+`OFTBridgeSteward` is an Aave Steward that bridges USDT from a non-Ethereum chain to the Ethereum mainnet Collector using USDT0 OFT (Omnichain Fungible Token) over LayerZero V2. The transfer is 1:1 with no slippage.
+
+The steward is unidirectional: every deployed instance bridges *to* Ethereum mainnet. The destination endpoint and receiver are immutable, set at construction time (see `DESTINATION_EID` and `RECEIVER`).
 
 ## How USDT0 Works
 
@@ -8,102 +10,112 @@ USDT0 is Tether's official cross-chain solution using LayerZero's OFT standard. 
 
 ### Architecture
 
-- **On Ethereum**: Uses `OAdapterUpgradeable` which locks native USDT and sends LayerZero message
-- **On Other Chains**: Uses `OUpgradeable` which mints/burns USDT0
+- **On Ethereum (destination):** USDT0 uses `OAdapterUpgradeable` to release native USDT on receipt of a LayerZero message. The steward is **not** deployed on Ethereum.
+- **On other chains (source):** USDT0 uses `OUpgradeable` which burns USDT0 on send. The steward is deployed on these chains and calls `send` on the local OFT.
 
 ### Key Benefits
 
-- **No Slippage**: 1:1 lock/mint mechanism (unlike liquidity pool bridges)
-- **Unified Liquidity**: All USDT0 is backed 1:1 by USDT on Ethereum
-- **Dual DVN Security**: Verified by both LayerZero DVN and USDT0 DVN
+- **No Slippage:** 1:1 burn-on-source / release-on-destination mechanism.
+- **Unified Liquidity:** All USDT0 is backed 1:1 by USDT locked on Ethereum.
+- **Dual DVN Security:** Verified by both the LayerZero DVN and the USDT0 DVN.
 
 ## Functions
 
-### `bridge()`
+### `bridge(uint256 amount, uint256 minAmountLD, uint256 maxFee)`
 
-Bridges USDT to a destination chain. The steward pulls USDT from the Aave Collector via `ICollector.transfer()`, so it must have the Collector `FUNDS_ADMIN` role. The quoted LayerZero messaging fee should be supplied as native token value with the `bridge()` call.
+Bridges `amount` USDT to the immutable `RECEIVER` on Ethereum (`DESTINATION_EID`). Restricted to owner or guardian.
 
-### `quoteBridge()`
+- The steward pulls `amount` USDT from the local Collector via `ICollector.transfer`, so it must hold the Collector `FUNDS_ADMIN` role.
+- The native LayerZero fee is paid from the steward's own balance. It can be either pre-funded (use `receive()` or `transfer`) or supplied as `msg.value` on the same call — both add to `address(this).balance`, which is what the contract checks.
+- `minAmountLD` is the slippage floor passed through to the OFT.
+- `maxFee` caps the LayerZero `nativeFee`. The call reverts with `MaxFeeExceeded` if the quoted fee exceeds it. Always quote the fee first and pass a snug `maxFee` to avoid getting front-run by a fee spike.
+- LayerZero refunds any unused fee directly to the local Collector (the refund recipient is set to `COLLECTOR`).
 
-Returns the native token fee required for bridging. Call this before `bridge()` to know how much native token value to send with the transaction.
+### `quoteSendFee(uint256 amount, uint256 minAmountLD) returns (uint256)`
 
-### `quoteOFT()`
+Returns the native-token fee LayerZero will charge for `bridge(amount, minAmountLD, …)`. Use this to size `maxFee` and the value/balance to fund.
 
-Returns the expected amount to be received on the destination chain. Use this value as `minAmountLD` in the `bridge()` call.
+### `quoteAmountReceived(uint256 amount) returns (uint256)`
 
-For USDT0 OFT transfers, this should return the same amount (1:1, no slippage).
+Returns the amount of USDT the receiver will get on Ethereum for an `amount` send (after any OFT-level dust truncation). For USDT0 this equals `amount` (no slippage), but always re-quote on-chain rather than assume.
+
+### `rescueToken(address token)` / `rescueEth()`
+
+Sweeps the steward's full balance of `token` (or ETH) back to the local Collector. Restricted to owner or guardian.
 
 ## Usage Pattern
 
 ```solidity
-// 1. Quote the expected received amount
-uint256 expectedReceived = bridge.quoteOFT(dstEid, amount, receiver);
+// 1. Quote the expected received amount on Ethereum.
+uint256 expectedReceived = bridge.quoteAmountReceived(amount);
 
-// 2. Quote the native fee
-uint256 fee = bridge.quoteBridge(dstEid, amount, receiver, expectedReceived);
+// 2. Quote the LayerZero native fee.
+uint256 fee = bridge.quoteSendFee(amount, expectedReceived);
 
-// 3. Grant the steward the Collector FUNDS_ADMIN role
+// 3. Grant the steward FUNDS_ADMIN on the local Collector (one-time).
 IAccessControl(address(collector)).grantRole(
     ICollector(address(collector)).FUNDS_ADMIN_ROLE(),
     address(bridge)
 );
 
-// 4. Execute the bridge, sending the quoted native fee
-bridge.bridge{value: fee}(dstEid, amount, receiver, expectedReceived, fee);
+// 4. Execute the bridge. Either pre-fund the steward with `fee` wei
+//    of native, or supply it as msg.value on the same call.
+bridge.bridge{value: fee}(amount, expectedReceived, fee);
 ```
 
 ## Permissions
 
-The contract implements `OwnableWithGuardian` for permissioned functions. The owner should be the respective network's Level 1 Executor (Governance), and the guardian should be a trusted operations role.
+The contract uses `OwnableWithGuardian`. The owner should be the local network's Level 1 Executor (Aave Governance); the guardian is a trusted ops role.
 
-The steward must also be granted the Collector `FUNDS_ADMIN` role so it can call `ICollector.transfer()`.
+The steward must also hold the local Collector `FUNDS_ADMIN` role so it can call `ICollector.transfer`.
 
 The owner or guardian can:
 
-- Call `bridge()` to initiate transfers
-- Call rescue functions to return assets to the Collector
+- Call `bridge()` to initiate transfers.
+- Call `rescueToken()` / `rescueEth()` to sweep stuck assets back to the local Collector.
 
 Only the owner can:
 
-- Update allowed receivers
-- Transfer ownership
+- Transfer ownership.
+
+There is no allow-list of receivers: `RECEIVER` is set at deployment time and immutable.
 
 ## Security Considerations
 
-- The contract inherits from `RescuableBase`, exposing rescue hooks used by the steward's rescue functions
-- Slippage protection via `minAmountLD` parameter prevents receiving less than expected
-- The `quoteOFT()` function should be called immediately before bridging to get accurate amounts
-- Only the owner or guardian can execute bridges, and only to explicitly allowed receivers
+- **Slippage protection:** `minAmountLD` enforces the floor for tokens received on Ethereum. Quote `quoteAmountReceived` immediately before sending.
+- **Fee protection:** `maxFee` caps the LayerZero native fee, avoiding open-ended drains if quoting and execution land in different blocks.
+- **Approval hygiene:** The steward `forceApprove`s the OFT for exactly `amount`, then resets to `0` after `send`, so no allowance is left dangling.
+- **Refund routing:** LayerZero's refund recipient is hard-coded to the local `COLLECTOR`, so excess native fee goes back to Aave directly.
+- **Rescue path:** Inherits `RescuableBase`; `maxRescue` returns the steward's full token balance, allowing complete sweep.
+- **Fixed destination/receiver:** `DESTINATION_EID` (Ethereum mainnet) and `RECEIVER` are immutable, removing destination-spoofing surface.
 
 ## Retry Mechanism
 
-LayerZero includes a retry mechanism to handle transactions which fail to execute on the destination chain.
-
-Because LayerZero separates the verification of a message from its execution, if a message fails to execute, it can be retried without having to resend it from the origin chain. This is possible because the message has already been confirmed by the DVNs as a valid message packet, meaning execution can be retried at any time, by anyone.
+LayerZero supports retrying messages that fail to execute on the destination chain. Because verification (DVN attestation) is decoupled from execution, an already-verified message can be re-executed by anyone without resending it from the source chain.
 
 ### How to Retry
 
-To retry a failed message:
+1. **LayerZero Scan UI:** find the failed message at [layerzeroscan.com](https://layerzeroscan.com/) and trigger a retry.
+2. **Direct call:** invoke `lzReceive` on the destination Endpoint contract.
 
-1. **LayerZero Scan Interface**: Use the [LayerZero Scan](https://layerzeroscan.com/) UI to locate and retry the failed message
-2. **Direct Contract Call**: Call the `lzReceive` function directly on the Endpoint contract
-
-For more details, see the [LayerZero debugging documentation](https://docs.layerzero.network/v2/developers/evm/troubleshooting/debugging-messages#retry-message).
+See the [LayerZero debugging documentation](https://docs.layerzero.network/v2/developers/evm/troubleshooting/debugging-messages#retry-message) for details.
 
 ## Supported Chains
 
-USDT0 is currently deployed on the following chains:
+USDT0 is currently deployed on the chains below. Endpoint IDs / OFT addresses are mirrored in [`OFTConstants.sol`](./OFTConstants.sol).
 
 ### Endpoint IDs and OFT Contracts
 
-| Chain    | Endpoint ID | USDT0 OFT Contract                         | Notes                            |
-| -------- | ----------- | ------------------------------------------ | -------------------------------- |
-| Ethereum | 30101       | 0x6C96dE32CEa08842dcc4058c14d3aaAD7Fa41dee | OAdapterUpgradeable (locks USDT) |
-| Arbitrum | 30110       | 0x14E4A1B13bf7F943c8ff7C51fb60FA964A298D92 | OUpgradeable                     |
-| Polygon  | 30109       | 0x6BA10300f0DC58B7a1e4c0e41f5daBb7D7829e13 | OUpgradeable                     |
-| Optimism | 30111       | 0xF03b4d9AC1D5d1E7c4cEf54C2A313b9fe051A0aD | OUpgradeable                     |
-| Ink      | 30339       | 0x0200C29006150606B650577BBE7B6248F58470c1 | OUpgradeable                     |
-| Plasma   | 30383       | 0x02ca37966753bDdDf11216B73B16C1dE756A7CF9 | OUpgradeable                     |
+| Chain    | Role        | Endpoint ID | USDT0 OFT Contract                         | Notes                            |
+| -------- | ----------- | ----------- | ------------------------------------------ | -------------------------------- |
+| Ethereum | Destination | 30101       | 0x6C96dE32CEa08842dcc4058c14d3aaAD7Fa41dee | OAdapterUpgradeable (locks USDT) |
+| Arbitrum | Source      | 30110       | 0x14E4A1B13bf7F943c8ff7C51fb60FA964A298D92 | OUpgradeable                     |
+| Polygon  | Source      | 30109       | 0x6BA10300f0DC58B7a1e4c0e41f5daBb7D7829e13 | OUpgradeable                     |
+| Optimism | Source      | 30111       | 0xF03b4d9AC1D5d1E7c4cEf54C2A313b9fe051A0aD | OUpgradeable                     |
+| Ink      | Source      | 30339       | 0x0200C29006150606B650577BBE7B6248F58470c1 | OUpgradeable (no deploy script)  |
+| Plasma   | Source      | 30383       | 0x02ca37966753bDdDf11216B73B16C1dE756A7CF9 | OUpgradeable                     |
+
+The steward is deployed on each *source* chain. Deployment scripts live in [`scripts/DeployOFTBridge.s.sol`](../../../scripts/DeployOFTBridge.s.sol) and currently cover Arbitrum, Polygon, Optimism, and Plasma.
 
 ### USDT Token Addresses
 
@@ -125,9 +137,9 @@ USDT0 is currently deployed on the following chains:
 
 ## Known Limitations
 
-1. **USDT0 Only**: Only transfers within the USDT0 system are supported.
-
-2. **LayerZero Fees**: A small native token fee is required for the LayerZero messaging. Use `quoteBridge()` to get the exact fee.
+1. **Destination is fixed to Ethereum mainnet.** A new contract deployment is required to bridge to any other chain.
+2. **USDT0 only.** Only USDT transfers within the USDT0 system are supported.
+3. **LayerZero native fee.** A small native-token fee is required for messaging. Quote it with `quoteSendFee` before each call.
 
 ## References
 

--- a/src/bridges/oft/interfaces/IAaveOFTBridgeSteward.sol
+++ b/src/bridges/oft/interfaces/IAaveOFTBridgeSteward.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IAaveOFTBridgeSteward {
+  /// @dev Thrown when the contract balance is not enough to pay the native fee
+  /// @param contractBalance The current balance of the contract
+  /// @param nativeFee The required native fee for the bridge
+  error InsufficientBalance(uint256 contractBalance, uint256 nativeFee);
+
+  /// @dev Thrown when bridge amount or min amount to receive is zero
+  error InvalidZeroAmount();
+
+  /// @dev Thrown when a zero address is provided
+  error InvalidZeroAddress();
+
+  /// @dev Thrown when the max fee is exceeded when bridging
+  /// @param requiredFee The required native fee for the bridge
+  /// @param maxFee The maximum fee allowed as specified in the bridge call
+  error MaxFeeExceeded(uint256 requiredFee, uint256 maxFee);
+
+  /// @notice Emitted when USDT is bridged to a destination chain
+  /// @param token The token address being bridged
+  /// @param dstEid The destination LayerZero endpoint ID
+  /// @param receiver The receiver address on destination
+  /// @param amount The amount bridged
+  /// @param minAmountReceived The minimum expected amount on destination
+  event Bridge(
+    address indexed token, uint32 indexed dstEid, address indexed receiver, uint256 amount, uint256 minAmountReceived
+  );
+
+  /// @notice Bridges USDT to a destination chain using OFT
+  /// @dev Only callable by owner or guardian. Requires contract to hold at least the native fee for the bridge,
+  ///      either paid for in this call or beforehand.
+  ///      The bridged USDT will be pulled from the Collector, so the Collector must have approved this contract to
+  ///      spend the specified amount of USDT.
+  /// @param amount The amount of USDT to bridge
+  /// @param minAmountLD The minimum amount to receive on destination (slippage protection)
+  /// @param maxFee The maximum native fee in ETH wei allowed for the bridge
+  function bridge(uint256 amount, uint256 minAmountLD, uint256 maxFee) external payable;
+
+  /// @notice Rescues the specified token back to the Collector
+  /// @param token The address of the ERC20 token to rescue
+  function rescueToken(address token) external;
+
+  /// @notice Rescues ETH from the contract back to the Collector
+  function rescueEth() external;
+
+  /// @notice Returns Mainnet EID (LayerZero Endpoint ID) for bridging
+  function DESTINATION_EID() external view returns (uint32);
+
+  /// @notice Returns the OFT address for USDT on the deployed chain
+  function OFT_USDT() external view returns (address);
+
+  /// @notice Returns the USDT token address on the deployed chain
+  function USDT() external view returns (address);
+
+  /// @notice Returns the Aave Collector address
+  function COLLECTOR() external view returns (address);
+
+  /// @notice Returns the receiver address for bridged tokens on the destination chain (Mainnet Collector)
+  function RECEIVER() external view returns (address);
+
+  /// @notice Quotes the native fee required to bridge USDT
+  /// @param amount The amount of USDT to bridge
+  /// @param minAmountLD The minimum amount to receive on destination
+  /// @return nativeFee The native token fee required for bridging
+  function quoteSendFee(uint256 amount, uint256 minAmountLD) external view returns (uint256);
+
+  /// @notice Quotes the amount of USDT expected to be received on the destination chain
+  /// @param amount The amount of USDT to bridge
+  /// @return amountReceivedLD The amount of USDT expected to be received on the destination chain
+  function quoteAmountReceived(uint256 amount) external view returns (uint256);
+}

--- a/src/bridges/oft/interfaces/IAaveOFTBridgeSteward.sol
+++ b/src/bridges/oft/interfaces/IAaveOFTBridgeSteward.sol
@@ -33,6 +33,8 @@ interface IAaveOFTBridgeSteward {
   ///      either paid for in this call or beforehand.
   ///      The bridged USDT will be pulled from the Collector, so the Collector must have approved this contract to
   ///      spend the specified amount of USDT.
+  ///      Any `msg.value` in excess of the LayerZero native fee is retained on the contract and is recoverable
+  ///      via `rescueEth`.
   /// @param amount The amount of USDT to bridge
   /// @param minAmountLD The minimum amount to receive on destination (slippage protection)
   /// @param maxFee The maximum native fee in ETH wei allowed for the bridge
@@ -57,7 +59,8 @@ interface IAaveOFTBridgeSteward {
   /// @notice Returns the Aave Collector address
   function COLLECTOR() external view returns (address);
 
-  /// @notice Returns the receiver address for bridged tokens on the destination chain (Mainnet Collector)
+  /// @notice Returns the receiver address for bridged tokens on Ethereum mainnet (the Mainnet Collector at deploy time).
+  /// @dev Immutable; a Collector migration requires redeploying the steward.
   function RECEIVER() external view returns (address);
 
   /// @notice Quotes the native fee required to bridge USDT

--- a/src/bridges/oft/interfaces/IOFT.sol
+++ b/src/bridges/oft/interfaces/IOFT.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @dev Struct representing the fee for LayerZero messaging
+struct MessagingFee {
+  uint256 nativeFee;
+  uint256 lzTokenFee;
+}
+
+/// @dev Struct representing the receipt from LayerZero messaging
+struct MessagingReceipt {
+  bytes32 guid;
+  uint64 nonce;
+  MessagingFee fee;
+}
+
+/// @dev Struct representing token parameters for the OFT send() operation
+struct SendParam {
+  uint32 dstEid;
+  bytes32 to;
+  uint256 amountLD;
+  uint256 minAmountLD;
+  bytes extraOptions;
+  bytes composeMsg;
+  bytes oftCmd;
+}
+
+/// @dev Struct representing OFT limit information
+struct OFTLimit {
+  uint256 minAmountLD;
+  uint256 maxAmountLD;
+}
+
+/// @dev Struct representing OFT receipt information
+struct OFTReceipt {
+  uint256 amountSentLD;
+  uint256 amountReceivedLD;
+}
+
+/// @dev Struct representing OFT fee details
+struct OFTFeeDetail {
+  int256 feeAmountLD;
+  string description;
+}
+
+/// @title IOFT
+/// @dev Interface for the OFT (Omnichain Fungible Token) standard
+/// @dev This specific interface ID is '0x02e49c2c'
+interface IOFT {
+  error InvalidLocalDecimals();
+  error SlippageExceeded(uint256 amountLD, uint256 minAmountLD);
+
+  event OFTSent(
+    bytes32 indexed guid, uint32 dstEid, address indexed fromAddress, uint256 amountSentLD, uint256 amountReceivedLD
+  );
+
+  event OFTReceived(bytes32 indexed guid, uint32 srcEid, address indexed toAddress, uint256 amountReceivedLD);
+
+  /// @notice Retrieves interfaceID and the version of the OFT
+  function oftVersion() external view returns (bytes4 interfaceId, uint64 version);
+
+  /// @notice Retrieves the address of the token associated with the OFT
+  function token() external view returns (address);
+
+  /// @notice Indicates whether the OFT contract requires approval of the 'token()' to send
+  function approvalRequired() external view returns (bool);
+
+  /// @notice Retrieves the shared decimals of the OFT
+  function sharedDecimals() external view returns (uint8);
+
+  /// @notice Provides a quote for OFT-related operations
+  function quoteOFT(SendParam calldata _sendParam)
+    external
+    view
+    returns (OFTLimit memory, OFTFeeDetail[] memory oftFeeDetails, OFTReceipt memory);
+
+  /// @notice Provides a quote for the send() operation
+  function quoteSend(SendParam calldata _sendParam, bool _payInLzToken) external view returns (MessagingFee memory);
+
+  /// @notice Executes the send() operation
+  function send(SendParam calldata _sendParam, MessagingFee calldata _fee, address _refundAddress)
+    external
+    payable
+    returns (MessagingReceipt memory, OFTReceipt memory);
+}

--- a/src/bridges/oft/interfaces/IOFTBridgeSteward.sol
+++ b/src/bridges/oft/interfaces/IOFTBridgeSteward.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-interface IAaveOFTBridgeSteward {
+interface IOFTBridgeSteward {
   /// @dev Thrown when the contract balance is not enough to pay the native fee
   /// @param contractBalance The current balance of the contract
   /// @param nativeFee The required native fee for the bridge
@@ -23,16 +23,16 @@ interface IAaveOFTBridgeSteward {
   /// @param dstEid The destination LayerZero endpoint ID
   /// @param receiver The receiver address on destination
   /// @param amount The amount bridged
-  /// @param minAmountReceived The minimum expected amount on destination
+  /// @param minAmountLD The slippage floor passed to the OFT (minimum acceptable amount on destination)
   event Bridge(
-    address indexed token, uint32 indexed dstEid, address indexed receiver, uint256 amount, uint256 minAmountReceived
+    address indexed token, uint32 indexed dstEid, address indexed receiver, uint256 amount, uint256 minAmountLD
   );
 
   /// @notice Bridges USDT to a destination chain using OFT
   /// @dev Only callable by owner or guardian. Requires contract to hold at least the native fee for the bridge,
   ///      either paid for in this call or beforehand.
-  ///      The bridged USDT will be pulled from the Collector, so the Collector must have approved this contract to
-  ///      spend the specified amount of USDT.
+  ///      The bridged USDT is pulled from the Collector via `ICollector.transfer`, so the steward must hold
+  ///      `FUNDS_ADMIN_ROLE` on the Collector.
   ///      Any `msg.value` in excess of the LayerZero native fee is retained on the contract and is recoverable
   ///      via `rescueEth`.
   /// @param amount The amount of USDT to bridge

--- a/src/bridges/oft/interfaces/IOFTBridgeSteward.sol
+++ b/src/bridges/oft/interfaces/IOFTBridgeSteward.sol
@@ -35,6 +35,10 @@ interface IOFTBridgeSteward {
   ///      `FUNDS_ADMIN_ROLE` on the Collector.
   ///      Any `msg.value` in excess of the LayerZero native fee is retained on the contract and is recoverable
   ///      via `rescueEth`.
+  ///      The native fee returned by `quoteSendFee` is a quote and may drift between the off-chain quote
+  ///      and on-chain execution (LayerZero executor uses periodically-refreshed oracle price feeds for
+  ///      destination gas). The steward re-quotes inside `bridge` and uses the current on-chain fee;
+  ///      `maxFee` caps that fee and reverts with `MaxFeeExceeded` if the live fee exceeds it.
   /// @param amount The amount of USDT to bridge
   /// @param minAmountLD The minimum amount to receive on destination (slippage protection)
   /// @param maxFee The maximum native fee in ETH wei allowed for the bridge

--- a/src/bridges/oft/interfaces/IOFTBridgeSteward.sol
+++ b/src/bridges/oft/interfaces/IOFTBridgeSteward.sol
@@ -59,9 +59,8 @@ interface IOFTBridgeSteward {
   /// @notice Returns the Aave Collector address
   function COLLECTOR() external view returns (address);
 
-  /// @notice Returns the receiver address for bridged tokens on Ethereum mainnet (the Mainnet Collector at deploy time).
-  /// @dev Immutable; a Collector migration requires redeploying the steward.
-  function RECEIVER() external view returns (address);
+  /// @notice Returns the Mainnet collector address (destination receiver) for bridge transfers
+  function MAINNET_COLLECTOR() external view returns (address);
 
   /// @notice Quotes the native fee required to bridge USDT
   /// @param amount The amount of USDT to bridge

--- a/src/maintenance/ClinicStewardV2.sol
+++ b/src/maintenance/ClinicStewardV2.sol
@@ -41,11 +41,11 @@ contract ClinicStewardV2 is ClinicStewardBase {
     if (block.chainid == 1 || block.chainid == 137) {
       // @note In Aave V2 Polygon, Ethereum Core and AMM an oracle has ETH as a base currency
       if (block.chainid == 1) {
-        // `ChainlinkEthereum.ETH_USD` has 8 decimals
-        return priceFromOracle * uint256(AggregatorInterface(ChainlinkEthereum.ETH_USD).latestAnswer()) / 1e18;
+        // `ChainlinkEthereum.ETH__USD` has 8 decimals
+        return priceFromOracle * uint256(AggregatorInterface(ChainlinkEthereum.ETH__USD).latestAnswer()) / 1e18;
       } else {
-        // `ChainlinkPolygon.ETH_USD` has 8 decimals
-        return priceFromOracle * uint256(AggregatorInterface(ChainlinkPolygon.ETH_USD).latestAnswer()) / 1e18;
+        // `ChainlinkPolygon.ETH__USD` has 8 decimals
+        return priceFromOracle * uint256(AggregatorInterface(ChainlinkPolygon.ETH__USD).latestAnswer()) / 1e18;
       }
     } else {
       return priceFromOracle;

--- a/tests/bridges/oft/OFTBridgeForkTest.t.sol
+++ b/tests/bridges/oft/OFTBridgeForkTest.t.sol
@@ -13,7 +13,7 @@ import {IWithGuardian} from "solidity-utils/contracts/access-control/interfaces/
 import {OFTConstants} from "src/bridges/oft/OFTConstants.sol";
 import {OFTBridgeSteward} from "src/bridges/oft/OFTBridgeSteward.sol";
 import {IOFT} from "src/bridges/oft/interfaces/IOFT.sol";
-import {IAaveOFTBridgeSteward} from "src/bridges/oft/interfaces/IAaveOFTBridgeSteward.sol";
+import {IOFTBridgeSteward} from "src/bridges/oft/interfaces/IOFTBridgeSteward.sol";
 
 /**
  * @title OFTBridgeForkTestBase
@@ -36,7 +36,7 @@ contract OFTBridgeForkTestBase is Test {
   OFTBridgeSteward public arbitrumBridge;
 
   event Bridge(
-    address indexed token, uint32 indexed dstEid, address indexed receiver, uint256 amount, uint256 minAmountReceived
+    address indexed token, uint32 indexed dstEid, address indexed receiver, uint256 amount, uint256 minAmountLD
   );
 
   function setUp() public virtual {
@@ -200,24 +200,24 @@ contract ConstructorAndImmutablesTest is OFTBridgeForkTestBase {
   }
 
   function test_constructor_revertsIf_zeroGuardian() public {
-    vm.expectRevert(IAaveOFTBridgeSteward.InvalidZeroAddress.selector);
+    vm.expectRevert(IOFTBridgeSteward.InvalidZeroAddress.selector);
     new OFTBridgeSteward(
       OFTConstants.ETHEREUM_USDT0_OFT, owner, address(0), address(AaveV3Ethereum.COLLECTOR), mainnetReceiver
     );
   }
 
   function test_constructor_revertsIf_zeroCollector() public {
-    vm.expectRevert(IAaveOFTBridgeSteward.InvalidZeroAddress.selector);
+    vm.expectRevert(IOFTBridgeSteward.InvalidZeroAddress.selector);
     new OFTBridgeSteward(OFTConstants.ETHEREUM_USDT0_OFT, owner, guardian, address(0), mainnetReceiver);
   }
 
   function test_constructor_revertsIf_zeroOft() public {
-    vm.expectRevert(IAaveOFTBridgeSteward.InvalidZeroAddress.selector);
+    vm.expectRevert(IOFTBridgeSteward.InvalidZeroAddress.selector);
     new OFTBridgeSteward(address(0), owner, guardian, address(AaveV3Ethereum.COLLECTOR), mainnetReceiver);
   }
 
   function test_constructor_revertsIf_zeroReceiver() public {
-    vm.expectRevert(IAaveOFTBridgeSteward.InvalidZeroAddress.selector);
+    vm.expectRevert(IOFTBridgeSteward.InvalidZeroAddress.selector);
     new OFTBridgeSteward(
       OFTConstants.ETHEREUM_USDT0_OFT, owner, guardian, address(AaveV3Ethereum.COLLECTOR), address(0)
     );

--- a/tests/bridges/oft/OFTBridgeForkTest.t.sol
+++ b/tests/bridges/oft/OFTBridgeForkTest.t.sol
@@ -308,9 +308,9 @@ contract BridgeRevertsTest is OFTBridgeForkTestBase {
 
   function test_bridge_revertsIf_slippageExceeded() public {
     vm.deal(address(arbitrumBridge), quotedFee);
-    // Bare expectRevert: slippage is enforced by the underlying OFT and the exact selector / args
-    // depend on the live OFT implementation.
-    vm.expectRevert();
+    vm.expectRevert(
+      abi.encodeWithSelector(IOFT.SlippageExceeded.selector, LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT + 1)
+    );
     vm.prank(owner);
     arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT + 1, type(uint256).max);
   }

--- a/tests/bridges/oft/OFTBridgeForkTest.t.sol
+++ b/tests/bridges/oft/OFTBridgeForkTest.t.sol
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+import {IERC20} from "openzeppelin-contracts/contracts/token/ERC20/IERC20.sol";
+import {IAccessControl} from "openzeppelin-contracts/contracts/access/IAccessControl.sol";
+import {Ownable} from "openzeppelin-contracts/contracts/access/Ownable.sol";
+import {GovernanceV3Ethereum} from "aave-address-book/GovernanceV3Ethereum.sol";
+import {AaveV3Ethereum} from "aave-address-book/AaveV3Ethereum.sol";
+import {AaveV3Arbitrum} from "aave-address-book/AaveV3Arbitrum.sol";
+import {IWithGuardian} from "solidity-utils/contracts/access-control/interfaces/IWithGuardian.sol";
+
+import {OFTConstants} from "src/bridges/oft/OFTConstants.sol";
+import {OFTBridgeSteward} from "src/bridges/oft/OFTBridgeSteward.sol";
+import {IOFT} from "src/bridges/oft/interfaces/IOFT.sol";
+import {IAaveOFTBridgeSteward} from "src/bridges/oft/interfaces/IAaveOFTBridgeSteward.sol";
+
+/**
+ * @title OFTBridgeForkTestBase
+ * @notice Fork tests for USDT0 OFT bridge via LayerZero V2.
+ * @dev OFTBridgeSteward bridges *to* Ethereum (DESTINATION_EID is fixed to mainnet),
+ *      so end-to-end bridging is tested on the Arbitrum fork. The mainnet instance
+ *      only exercises constructor/immutable, ownership, and rescue paths.
+ */
+contract OFTBridgeForkTestBase is Test {
+  uint256 public constant LARGE_BRIDGE_AMOUNT = 10_000_000e6; // 10 million USDT
+
+  uint256 public mainnetFork;
+  uint256 public arbitrumFork;
+
+  address public owner = makeAddr("owner");
+  address public guardian = makeAddr("guardian");
+  address public mainnetReceiver;
+
+  OFTBridgeSteward public mainnetBridge;
+  OFTBridgeSteward public arbitrumBridge;
+
+  event Bridge(
+    address indexed token, uint32 indexed dstEid, address indexed receiver, uint256 amount, uint256 minAmountReceived
+  );
+
+  function setUp() public virtual {
+    // Receiver value is irrelevant for non-bridging mainnet tests; pick any non-zero address.
+    mainnetReceiver = address(AaveV3Arbitrum.COLLECTOR);
+
+    arbitrumFork = vm.createSelectFork(vm.rpcUrl("mainnet"));
+
+    mainnetBridge = new OFTBridgeSteward(
+      OFTConstants.ETHEREUM_USDT0_OFT, owner, guardian, address(AaveV3Ethereum.COLLECTOR), mainnetReceiver
+    );
+  }
+}
+
+/// @notice Quote tests for Arbitrum -> Ethereum USDT bridging via USDT0 OFT.
+contract QuoteArbitrumToEthereumTest is OFTBridgeForkTestBase {
+  function setUp() public override {
+    arbitrumFork = vm.createSelectFork(vm.rpcUrl("arbitrum"));
+
+    arbitrumBridge = new OFTBridgeSteward(
+      OFTConstants.ARBITRUM_USDT0_OFT,
+      owner,
+      guardian,
+      address(AaveV3Arbitrum.COLLECTOR),
+      address(AaveV3Ethereum.COLLECTOR)
+    );
+  }
+
+  function test_quoteSendFee_arbitrumToEthereum() public view {
+    uint256 fee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
+    assertGt(fee, 0, "Fee should be greater than 0");
+  }
+
+  function test_quoteAmountReceived_arbitrumToEthereum() public view {
+    uint256 amountReceived = arbitrumBridge.quoteAmountReceived(LARGE_BRIDGE_AMOUNT);
+    assertEq(amountReceived, LARGE_BRIDGE_AMOUNT, "OFT should have no slippage");
+  }
+
+  function test_quote_arbitrumToEthereum_10MillionUSDT() public view {
+    uint256 expectedReceived = arbitrumBridge.quoteAmountReceived(LARGE_BRIDGE_AMOUNT);
+    assertEq(expectedReceived, LARGE_BRIDGE_AMOUNT, "OFT should have no slippage");
+
+    uint256 fee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
+    assertGt(fee, 0, "Fee should be greater than 0");
+  }
+}
+
+/// @notice Tests for Arbitrum -> Ethereum USDT bridging via USDT0 OFT.
+contract BridgeArbitrumToEthereumTest is OFTBridgeForkTestBase {
+  function setUp() public override {
+    arbitrumFork = vm.createSelectFork(vm.rpcUrl("arbitrum"));
+
+    arbitrumBridge = new OFTBridgeSteward(
+      OFTConstants.ARBITRUM_USDT0_OFT,
+      owner,
+      guardian,
+      address(AaveV3Arbitrum.COLLECTOR),
+      address(AaveV3Ethereum.COLLECTOR)
+    );
+
+    bytes32 fundsAdminRole = AaveV3Arbitrum.COLLECTOR.FUNDS_ADMIN_ROLE();
+    vm.prank(AaveV3Arbitrum.ACL_ADMIN);
+    IAccessControl(address(AaveV3Arbitrum.COLLECTOR)).grantRole(fundsAdminRole, address(arbitrumBridge));
+  }
+
+  function test_bridge_arbitrumToEthereum_10MillionUSDT() public {
+    address ethReceiver = address(AaveV3Ethereum.COLLECTOR);
+
+    deal(OFTConstants.ARBITRUM_USDT, address(AaveV3Arbitrum.COLLECTOR), LARGE_BRIDGE_AMOUNT);
+    assertEq(
+      IERC20(OFTConstants.ARBITRUM_USDT).balanceOf(address(AaveV3Arbitrum.COLLECTOR)),
+      LARGE_BRIDGE_AMOUNT,
+      "Collector should have USDT"
+    );
+
+    uint256 expectedReceived = arbitrumBridge.quoteAmountReceived(LARGE_BRIDGE_AMOUNT);
+    assertEq(expectedReceived, LARGE_BRIDGE_AMOUNT, "OFT should have no slippage");
+
+    uint256 fee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
+    vm.deal(address(arbitrumBridge), fee + 1 ether);
+    uint256 totalSupplyBefore = IERC20(OFTConstants.ARBITRUM_USDT).totalSupply();
+
+    vm.expectEmit(true, true, true, true, address(arbitrumBridge));
+    emit Bridge(
+      OFTConstants.ARBITRUM_USDT, OFTConstants.ETHEREUM_EID, ethReceiver, LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT
+    );
+
+    vm.prank(owner);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, fee);
+
+    assertEq(
+      IERC20(OFTConstants.ARBITRUM_USDT).balanceOf(address(AaveV3Arbitrum.COLLECTOR)),
+      0,
+      "Collector should have 0 USDT after bridging"
+    );
+    assertEq(
+      IERC20(OFTConstants.ARBITRUM_USDT).balanceOf(address(arbitrumBridge)),
+      0,
+      "Bridge should have 0 USDT after bridging"
+    );
+    assertEq(
+      IERC20(OFTConstants.ARBITRUM_USDT).totalSupply(),
+      totalSupplyBefore - LARGE_BRIDGE_AMOUNT,
+      "USDT should be burned on Arbitrum"
+    );
+    assertEq(
+      IERC20(OFTConstants.ARBITRUM_USDT).allowance(address(arbitrumBridge), OFTConstants.ARBITRUM_USDT0_OFT),
+      0,
+      "Allowance between bridge and OFT should be 0"
+    );
+  }
+}
+
+contract RescueTokenTest is OFTBridgeForkTestBase {
+  function test_rescueToken() public {
+    uint256 amount = 1_000_000e6;
+    deal(OFTConstants.ETHEREUM_USDT, address(mainnetBridge), amount);
+
+    uint256 collectorBalanceBefore = IERC20(OFTConstants.ETHEREUM_USDT).balanceOf(address(AaveV3Ethereum.COLLECTOR));
+
+    vm.prank(owner);
+    mainnetBridge.rescueToken(OFTConstants.ETHEREUM_USDT);
+
+    assertEq(
+      IERC20(OFTConstants.ETHEREUM_USDT).balanceOf(address(AaveV3Ethereum.COLLECTOR)),
+      collectorBalanceBefore + amount,
+      "Collector should receive tokens"
+    );
+    assertEq(IERC20(OFTConstants.ETHEREUM_USDT).balanceOf(address(mainnetBridge)), 0, "Bridge should have 0 balance");
+  }
+}
+
+/// @notice Tests for constructor and immutable values.
+contract ConstructorAndImmutablesTest is OFTBridgeForkTestBase {
+  function test_constructor_setsImmutables() public view {
+    assertEq(mainnetBridge.OFT_USDT(), OFTConstants.ETHEREUM_USDT0_OFT, "OFT_USDT should be set correctly");
+    assertEq(mainnetBridge.USDT(), OFTConstants.ETHEREUM_USDT, "USDT should be set correctly");
+    assertEq(mainnetBridge.owner(), owner, "Owner should be set correctly");
+    assertEq(mainnetBridge.guardian(), guardian, "Guardian should be set correctly");
+    assertEq(mainnetBridge.COLLECTOR(), address(AaveV3Ethereum.COLLECTOR), "Collector should be set correctly");
+    assertEq(mainnetBridge.RECEIVER(), mainnetReceiver, "Receiver should be set correctly");
+  }
+
+  function test_constructor_arbitrumBridge() public {
+    arbitrumFork = vm.createSelectFork(vm.rpcUrl("arbitrum"));
+
+    arbitrumBridge = new OFTBridgeSteward(
+      OFTConstants.ARBITRUM_USDT0_OFT,
+      owner,
+      guardian,
+      address(AaveV3Arbitrum.COLLECTOR),
+      address(AaveV3Ethereum.COLLECTOR)
+    );
+
+    assertEq(arbitrumBridge.OFT_USDT(), OFTConstants.ARBITRUM_USDT0_OFT, "OFT_USDT should be set correctly");
+    assertEq(arbitrumBridge.USDT(), OFTConstants.ARBITRUM_USDT, "USDT should be set correctly");
+    assertEq(arbitrumBridge.owner(), owner, "Owner should be set correctly");
+    assertEq(arbitrumBridge.guardian(), guardian, "Guardian should be set correctly");
+    assertEq(arbitrumBridge.COLLECTOR(), address(AaveV3Arbitrum.COLLECTOR), "Collector should be set correctly");
+    assertEq(arbitrumBridge.RECEIVER(), address(AaveV3Ethereum.COLLECTOR), "Receiver should be set correctly");
+  }
+
+  function test_constructor_revertsIf_zeroGuardian() public {
+    vm.expectRevert(IAaveOFTBridgeSteward.InvalidZeroAddress.selector);
+    new OFTBridgeSteward(
+      OFTConstants.ETHEREUM_USDT0_OFT, owner, address(0), address(AaveV3Ethereum.COLLECTOR), mainnetReceiver
+    );
+  }
+
+  function test_constructor_revertsIf_zeroCollector() public {
+    vm.expectRevert(IAaveOFTBridgeSteward.InvalidZeroAddress.selector);
+    new OFTBridgeSteward(OFTConstants.ETHEREUM_USDT0_OFT, owner, guardian, address(0), mainnetReceiver);
+  }
+
+  function test_constructor_revertsIf_zeroOft() public {
+    vm.expectRevert(IAaveOFTBridgeSteward.InvalidZeroAddress.selector);
+    new OFTBridgeSteward(address(0), owner, guardian, address(AaveV3Ethereum.COLLECTOR), mainnetReceiver);
+  }
+
+  function test_constructor_revertsIf_zeroReceiver() public {
+    vm.expectRevert(IAaveOFTBridgeSteward.InvalidZeroAddress.selector);
+    new OFTBridgeSteward(
+      OFTConstants.ETHEREUM_USDT0_OFT, owner, guardian, address(AaveV3Ethereum.COLLECTOR), address(0)
+    );
+  }
+}
+
+/// @notice Tests for receive function and native token handling.
+contract ReceiveFunctionTest is OFTBridgeForkTestBase {
+  function test_receive_acceptsNativeTokens() public {
+    uint256 balanceBefore = address(mainnetBridge).balance;
+
+    address sender = makeAddr("sender");
+    vm.deal(sender, 10 ether);
+
+    vm.prank(sender);
+    (bool success,) = address(mainnetBridge).call{value: 1 ether}("");
+
+    assertTrue(success, "Should accept native tokens");
+    assertEq(address(mainnetBridge).balance, balanceBefore + 1 ether, "Balance should increase");
+  }
+}
+
+/// @notice Tests for rescue functionality.
+contract RescuableTest is OFTBridgeForkTestBase {
+  function test_maxRescue_returnsBridgeBalance() public {
+    uint256 amount = 2_500e6;
+    deal(OFTConstants.ETHEREUM_USDT, address(mainnetBridge), amount);
+
+    assertEq(
+      mainnetBridge.maxRescue(OFTConstants.ETHEREUM_USDT), amount, "maxRescue should return bridge token balance"
+    );
+  }
+
+  function test_rescueToken_revertsIf_notOwnerOrGuardian() public {
+    address notOwner = makeAddr("not-owner");
+    uint256 amount = 1_000e6;
+    deal(OFTConstants.ETHEREUM_USDT, address(mainnetBridge), amount);
+
+    vm.prank(notOwner);
+    vm.expectRevert(abi.encodeWithSelector(IWithGuardian.OnlyGuardianOrOwnerInvalidCaller.selector, notOwner));
+    mainnetBridge.rescueToken(OFTConstants.ETHEREUM_USDT);
+  }
+
+  function test_rescueEth() public {
+    uint256 ethAmount = 5 ether;
+    vm.deal(address(mainnetBridge), ethAmount);
+
+    uint256 collectorBalanceBefore = address(AaveV3Ethereum.COLLECTOR).balance;
+
+    vm.prank(owner);
+    mainnetBridge.rescueEth();
+
+    assertEq(
+      address(AaveV3Ethereum.COLLECTOR).balance, collectorBalanceBefore + ethAmount, "Collector should receive ETH"
+    );
+    assertEq(address(mainnetBridge).balance, 0, "Bridge should have 0 ETH balance");
+  }
+}

--- a/tests/bridges/oft/OFTBridgeForkTest.t.sol
+++ b/tests/bridges/oft/OFTBridgeForkTest.t.sol
@@ -32,7 +32,7 @@ contract OFTBridgeForkTestBase is Test {
 
   address public owner = makeAddr("owner");
   address public guardian = makeAddr("guardian");
-  address public mainnetReceiver;
+  address public mainnetCollector = address(AaveV3Ethereum.COLLECTOR);
 
   OFTBridgeSteward public mainnetBridge;
   OFTBridgeSteward public arbitrumBridge;
@@ -42,14 +42,10 @@ contract OFTBridgeForkTestBase is Test {
   );
 
   function setUp() public virtual {
-    // Receiver value is irrelevant for non-bridging mainnet tests; pick any non-zero address.
-    mainnetReceiver = address(AaveV3Arbitrum.COLLECTOR);
-
     arbitrumFork = vm.createSelectFork(vm.rpcUrl("mainnet"));
 
-    mainnetBridge = new OFTBridgeSteward(
-      OFTConstants.ETHEREUM_USDT0_OFT, owner, guardian, address(AaveV3Ethereum.COLLECTOR), mainnetReceiver
-    );
+    mainnetBridge =
+      new OFTBridgeSteward(OFTConstants.ETHEREUM_USDT0_OFT, owner, guardian, address(AaveV3Ethereum.COLLECTOR));
   }
 
   /// @dev Spins up an Arbitrum fork, deploys an `arbitrumBridge`, and optionally
@@ -59,13 +55,8 @@ contract OFTBridgeForkTestBase is Test {
   {
     arbitrumFork = vm.createSelectFork(vm.rpcUrl("arbitrum"));
 
-    arbitrumBridge = new OFTBridgeSteward(
-      OFTConstants.ARBITRUM_USDT0_OFT,
-      owner,
-      guardian,
-      address(AaveV3Arbitrum.COLLECTOR),
-      address(AaveV3Ethereum.COLLECTOR)
-    );
+    arbitrumBridge =
+      new OFTBridgeSteward(OFTConstants.ARBITRUM_USDT0_OFT, owner, guardian, address(AaveV3Arbitrum.COLLECTOR));
 
     if (grantFundsAdminRole) {
       bytes32 fundsAdminRole = AaveV3Arbitrum.COLLECTOR.FUNDS_ADMIN_ROLE();
@@ -88,13 +79,8 @@ contract QuoteArbitrumToEthereumTest is OFTBridgeForkTestBase {
   function setUp() public override {
     arbitrumFork = vm.createSelectFork(vm.rpcUrl("arbitrum"));
 
-    arbitrumBridge = new OFTBridgeSteward(
-      OFTConstants.ARBITRUM_USDT0_OFT,
-      owner,
-      guardian,
-      address(AaveV3Arbitrum.COLLECTOR),
-      address(AaveV3Ethereum.COLLECTOR)
-    );
+    arbitrumBridge =
+      new OFTBridgeSteward(OFTConstants.ARBITRUM_USDT0_OFT, owner, guardian, address(AaveV3Arbitrum.COLLECTOR));
   }
 
   function test_quoteSendFee_arbitrumToEthereum() public view {
@@ -121,13 +107,8 @@ contract BridgeArbitrumToEthereumTest is OFTBridgeForkTestBase {
   function setUp() public override {
     arbitrumFork = vm.createSelectFork(vm.rpcUrl("arbitrum"));
 
-    arbitrumBridge = new OFTBridgeSteward(
-      OFTConstants.ARBITRUM_USDT0_OFT,
-      owner,
-      guardian,
-      address(AaveV3Arbitrum.COLLECTOR),
-      address(AaveV3Ethereum.COLLECTOR)
-    );
+    arbitrumBridge =
+      new OFTBridgeSteward(OFTConstants.ARBITRUM_USDT0_OFT, owner, guardian, address(AaveV3Arbitrum.COLLECTOR));
 
     bytes32 fundsAdminRole = AaveV3Arbitrum.COLLECTOR.FUNDS_ADMIN_ROLE();
     vm.prank(AaveV3Arbitrum.ACL_ADMIN);
@@ -135,8 +116,6 @@ contract BridgeArbitrumToEthereumTest is OFTBridgeForkTestBase {
   }
 
   function test_bridge_arbitrumToEthereum_10MillionUSDT() public {
-    address ethReceiver = address(AaveV3Ethereum.COLLECTOR);
-
     deal(OFTConstants.ARBITRUM_USDT, address(AaveV3Arbitrum.COLLECTOR), LARGE_BRIDGE_AMOUNT);
     assertEq(
       IERC20(OFTConstants.ARBITRUM_USDT).balanceOf(address(AaveV3Arbitrum.COLLECTOR)),
@@ -153,7 +132,7 @@ contract BridgeArbitrumToEthereumTest is OFTBridgeForkTestBase {
 
     vm.expectEmit(true, true, true, true, address(arbitrumBridge));
     emit Bridge(
-      OFTConstants.ARBITRUM_USDT, OFTConstants.ETHEREUM_EID, ethReceiver, LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT
+      OFTConstants.ARBITRUM_USDT, OFTConstants.ETHEREUM_EID, mainnetCollector, LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT
     );
 
     vm.prank(owner);
@@ -209,50 +188,38 @@ contract ConstructorAndImmutablesTest is OFTBridgeForkTestBase {
     assertEq(mainnetBridge.owner(), owner, "Owner should be set correctly");
     assertEq(mainnetBridge.guardian(), guardian, "Guardian should be set correctly");
     assertEq(mainnetBridge.COLLECTOR(), address(AaveV3Ethereum.COLLECTOR), "Collector should be set correctly");
-    assertEq(mainnetBridge.RECEIVER(), mainnetReceiver, "Receiver should be set correctly");
+    assertEq(mainnetBridge.MAINNET_COLLECTOR(), mainnetCollector, "Mainnet collector should be set correctly");
   }
 
   function test_constructor_arbitrumBridge() public {
     arbitrumFork = vm.createSelectFork(vm.rpcUrl("arbitrum"));
 
-    arbitrumBridge = new OFTBridgeSteward(
-      OFTConstants.ARBITRUM_USDT0_OFT,
-      owner,
-      guardian,
-      address(AaveV3Arbitrum.COLLECTOR),
-      address(AaveV3Ethereum.COLLECTOR)
-    );
+    arbitrumBridge =
+      new OFTBridgeSteward(OFTConstants.ARBITRUM_USDT0_OFT, owner, guardian, address(AaveV3Arbitrum.COLLECTOR));
 
     assertEq(arbitrumBridge.OFT_USDT(), OFTConstants.ARBITRUM_USDT0_OFT, "OFT_USDT should be set correctly");
     assertEq(arbitrumBridge.USDT(), OFTConstants.ARBITRUM_USDT, "USDT should be set correctly");
     assertEq(arbitrumBridge.owner(), owner, "Owner should be set correctly");
     assertEq(arbitrumBridge.guardian(), guardian, "Guardian should be set correctly");
     assertEq(arbitrumBridge.COLLECTOR(), address(AaveV3Arbitrum.COLLECTOR), "Collector should be set correctly");
-    assertEq(arbitrumBridge.RECEIVER(), address(AaveV3Ethereum.COLLECTOR), "Receiver should be set correctly");
+    assertEq(
+      arbitrumBridge.MAINNET_COLLECTOR(), address(AaveV3Ethereum.COLLECTOR), "Mainnet collector should be set correctly"
+    );
   }
 
   function test_constructor_revertsIf_zeroGuardian() public {
     vm.expectRevert(IOFTBridgeSteward.InvalidZeroAddress.selector);
-    new OFTBridgeSteward(
-      OFTConstants.ETHEREUM_USDT0_OFT, owner, address(0), address(AaveV3Ethereum.COLLECTOR), mainnetReceiver
-    );
+    new OFTBridgeSteward(OFTConstants.ETHEREUM_USDT0_OFT, owner, address(0), address(AaveV3Ethereum.COLLECTOR));
   }
 
   function test_constructor_revertsIf_zeroCollector() public {
     vm.expectRevert(IOFTBridgeSteward.InvalidZeroAddress.selector);
-    new OFTBridgeSteward(OFTConstants.ETHEREUM_USDT0_OFT, owner, guardian, address(0), mainnetReceiver);
+    new OFTBridgeSteward(OFTConstants.ETHEREUM_USDT0_OFT, owner, guardian, address(0));
   }
 
   function test_constructor_revertsIf_zeroOft() public {
     vm.expectRevert(IOFTBridgeSteward.InvalidZeroAddress.selector);
-    new OFTBridgeSteward(address(0), owner, guardian, address(AaveV3Ethereum.COLLECTOR), mainnetReceiver);
-  }
-
-  function test_constructor_revertsIf_zeroReceiver() public {
-    vm.expectRevert(IOFTBridgeSteward.InvalidZeroAddress.selector);
-    new OFTBridgeSteward(
-      OFTConstants.ETHEREUM_USDT0_OFT, owner, guardian, address(AaveV3Ethereum.COLLECTOR), address(0)
-    );
+    new OFTBridgeSteward(address(0), owner, guardian, address(AaveV3Ethereum.COLLECTOR));
   }
 }
 
@@ -314,11 +281,7 @@ contract BridgeRevertsTest is OFTBridgeForkTestBase {
   uint256 public quotedFee;
 
   function setUp() public override {
-    _setUpArbitrumBridge({
-      grantFundsAdminRole: true,
-      dealUsdtToCollector: LARGE_BRIDGE_AMOUNT,
-      dealNativeToBridge: 0
-    });
+    _setUpArbitrumBridge({grantFundsAdminRole: true, dealUsdtToCollector: LARGE_BRIDGE_AMOUNT, dealNativeToBridge: 0});
     quotedFee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
   }
 
@@ -362,11 +325,7 @@ contract BridgeAccessControlTest is OFTBridgeForkTestBase {
   uint256 public quotedFee;
 
   function setUp() public override {
-    _setUpArbitrumBridge({
-      grantFundsAdminRole: true,
-      dealUsdtToCollector: LARGE_BRIDGE_AMOUNT,
-      dealNativeToBridge: 0
-    });
+    _setUpArbitrumBridge({grantFundsAdminRole: true, dealUsdtToCollector: LARGE_BRIDGE_AMOUNT, dealNativeToBridge: 0});
     quotedFee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
     vm.deal(address(arbitrumBridge), quotedFee);
   }
@@ -394,9 +353,7 @@ contract BridgeAccessControlTest is OFTBridgeForkTestBase {
     arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, quotedFee);
 
     assertEq(
-      IERC20(OFTConstants.ARBITRUM_USDT).totalSupply(),
-      totalSupplyBefore - LARGE_BRIDGE_AMOUNT,
-      "USDT should be burned"
+      IERC20(OFTConstants.ARBITRUM_USDT).totalSupply(), totalSupplyBefore - LARGE_BRIDGE_AMOUNT, "USDT should be burned"
     );
   }
 }
@@ -406,11 +363,7 @@ contract BridgeMissingRoleTest is OFTBridgeForkTestBase {
   uint256 public quotedFee;
 
   function setUp() public override {
-    _setUpArbitrumBridge({
-      grantFundsAdminRole: false,
-      dealUsdtToCollector: LARGE_BRIDGE_AMOUNT,
-      dealNativeToBridge: 0
-    });
+    _setUpArbitrumBridge({grantFundsAdminRole: false, dealUsdtToCollector: LARGE_BRIDGE_AMOUNT, dealNativeToBridge: 0});
     quotedFee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
     vm.deal(address(arbitrumBridge), quotedFee);
   }
@@ -473,9 +426,7 @@ contract RescueEthAccessControlTest is OFTBridgeForkTestBase {
     mainnetBridge.rescueEth();
 
     assertEq(
-      address(AaveV3Ethereum.COLLECTOR).balance,
-      collectorBalanceBefore + ETH_AMOUNT,
-      "Collector should receive ETH"
+      address(AaveV3Ethereum.COLLECTOR).balance, collectorBalanceBefore + ETH_AMOUNT, "Collector should receive ETH"
     );
     assertEq(address(mainnetBridge).balance, 0, "Bridge should have 0 ETH balance");
   }
@@ -486,11 +437,7 @@ contract BridgeNativeFeePathsTest is OFTBridgeForkTestBase {
   uint256 public quotedFee;
 
   function setUp() public override {
-    _setUpArbitrumBridge({
-      grantFundsAdminRole: true,
-      dealUsdtToCollector: LARGE_BRIDGE_AMOUNT,
-      dealNativeToBridge: 0
-    });
+    _setUpArbitrumBridge({grantFundsAdminRole: true, dealUsdtToCollector: LARGE_BRIDGE_AMOUNT, dealNativeToBridge: 0});
     quotedFee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
   }
 

--- a/tests/bridges/oft/OFTBridgeForkTest.t.sol
+++ b/tests/bridges/oft/OFTBridgeForkTest.t.sol
@@ -37,10 +37,6 @@ contract OFTBridgeForkTestBase is Test {
   OFTBridgeSteward public mainnetBridge;
   OFTBridgeSteward public arbitrumBridge;
 
-  event Bridge(
-    address indexed token, uint32 indexed dstEid, address indexed receiver, uint256 amount, uint256 minAmountLD
-  );
-
   function setUp() public virtual {
     arbitrumFork = vm.createSelectFork(vm.rpcUrl("mainnet"));
 
@@ -131,7 +127,7 @@ contract BridgeArbitrumToEthereumTest is OFTBridgeForkTestBase {
     uint256 totalSupplyBefore = IERC20(OFTConstants.ARBITRUM_USDT).totalSupply();
 
     vm.expectEmit(true, true, true, true, address(arbitrumBridge));
-    emit Bridge(
+    emit IOFTBridgeSteward.Bridge(
       OFTConstants.ARBITRUM_USDT, OFTConstants.ETHEREUM_EID, mainnetCollector, LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT
     );
 
@@ -341,7 +337,7 @@ contract BridgeAccessControlTest is OFTBridgeForkTestBase {
     uint256 totalSupplyBefore = IERC20(OFTConstants.ARBITRUM_USDT).totalSupply();
 
     vm.expectEmit(true, true, true, true, address(arbitrumBridge));
-    emit Bridge(
+    emit IOFTBridgeSteward.Bridge(
       OFTConstants.ARBITRUM_USDT,
       OFTConstants.ETHEREUM_EID,
       address(AaveV3Ethereum.COLLECTOR),

--- a/tests/bridges/oft/OFTBridgeForkTest.t.sol
+++ b/tests/bridges/oft/OFTBridgeForkTest.t.sol
@@ -10,6 +10,8 @@ import {AaveV3Ethereum} from "aave-address-book/AaveV3Ethereum.sol";
 import {AaveV3Arbitrum} from "aave-address-book/AaveV3Arbitrum.sol";
 import {IWithGuardian} from "solidity-utils/contracts/access-control/interfaces/IWithGuardian.sol";
 
+import {ICollector} from "aave-address-book/AaveV3.sol";
+
 import {OFTConstants} from "src/bridges/oft/OFTConstants.sol";
 import {OFTBridgeSteward} from "src/bridges/oft/OFTBridgeSteward.sol";
 import {IOFT} from "src/bridges/oft/interfaces/IOFT.sol";
@@ -48,6 +50,36 @@ contract OFTBridgeForkTestBase is Test {
     mainnetBridge = new OFTBridgeSteward(
       OFTConstants.ETHEREUM_USDT0_OFT, owner, guardian, address(AaveV3Ethereum.COLLECTOR), mainnetReceiver
     );
+  }
+
+  /// @dev Spins up an Arbitrum fork, deploys an `arbitrumBridge`, and optionally
+  ///      grants FUNDS_ADMIN, deals USDT to the local Collector, and pre-funds the steward.
+  function _setUpArbitrumBridge(bool grantFundsAdminRole, uint256 dealUsdtToCollector, uint256 dealNativeToBridge)
+    internal
+  {
+    arbitrumFork = vm.createSelectFork(vm.rpcUrl("arbitrum"));
+
+    arbitrumBridge = new OFTBridgeSteward(
+      OFTConstants.ARBITRUM_USDT0_OFT,
+      owner,
+      guardian,
+      address(AaveV3Arbitrum.COLLECTOR),
+      address(AaveV3Ethereum.COLLECTOR)
+    );
+
+    if (grantFundsAdminRole) {
+      bytes32 fundsAdminRole = AaveV3Arbitrum.COLLECTOR.FUNDS_ADMIN_ROLE();
+      vm.prank(AaveV3Arbitrum.ACL_ADMIN);
+      IAccessControl(address(AaveV3Arbitrum.COLLECTOR)).grantRole(fundsAdminRole, address(arbitrumBridge));
+    }
+
+    if (dealUsdtToCollector > 0) {
+      deal(OFTConstants.ARBITRUM_USDT, address(AaveV3Arbitrum.COLLECTOR), dealUsdtToCollector);
+    }
+
+    if (dealNativeToBridge > 0) {
+      vm.deal(address(arbitrumBridge), dealNativeToBridge);
+    }
   }
 }
 
@@ -274,5 +306,219 @@ contract RescuableTest is OFTBridgeForkTestBase {
       address(AaveV3Ethereum.COLLECTOR).balance, collectorBalanceBefore + ethAmount, "Collector should receive ETH"
     );
     assertEq(address(mainnetBridge).balance, 0, "Bridge should have 0 ETH balance");
+  }
+}
+
+/// @notice bridge() revert paths: maxFee cap, native balance, zero args, OFT-side slippage.
+contract BridgeRevertsTest is OFTBridgeForkTestBase {
+  uint256 public quotedFee;
+
+  function setUp() public override {
+    _setUpArbitrumBridge({
+      grantFundsAdminRole: true,
+      dealUsdtToCollector: LARGE_BRIDGE_AMOUNT,
+      dealNativeToBridge: 0
+    });
+    quotedFee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
+  }
+
+  function test_bridge_revertsIf_maxFeeExceeded() public {
+    vm.expectRevert(abi.encodeWithSelector(IOFTBridgeSteward.MaxFeeExceeded.selector, quotedFee, quotedFee - 1));
+    vm.prank(owner);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, quotedFee - 1);
+  }
+
+  function test_bridge_revertsIf_insufficientBalance() public {
+    // Steward deliberately not funded.
+    vm.expectRevert(abi.encodeWithSelector(IOFTBridgeSteward.InsufficientBalance.selector, 0, quotedFee));
+    vm.prank(owner);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, type(uint256).max);
+  }
+
+  function test_bridge_revertsIf_zeroAmount() public {
+    vm.expectRevert(IOFTBridgeSteward.InvalidZeroAmount.selector);
+    vm.prank(owner);
+    arbitrumBridge.bridge(0, 1, type(uint256).max);
+  }
+
+  function test_bridge_revertsIf_zeroMinAmountLD() public {
+    vm.expectRevert(IOFTBridgeSteward.InvalidZeroAmount.selector);
+    vm.prank(owner);
+    arbitrumBridge.bridge(1, 0, type(uint256).max);
+  }
+
+  function test_bridge_revertsIf_slippageExceeded() public {
+    vm.deal(address(arbitrumBridge), quotedFee);
+    // Bare expectRevert: slippage is enforced by the underlying OFT and the exact selector / args
+    // depend on the live OFT implementation.
+    vm.expectRevert();
+    vm.prank(owner);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT + 1, type(uint256).max);
+  }
+}
+
+/// @notice bridge() access control: non-owner/guardian rejection and the guardian happy path.
+contract BridgeAccessControlTest is OFTBridgeForkTestBase {
+  uint256 public quotedFee;
+
+  function setUp() public override {
+    _setUpArbitrumBridge({
+      grantFundsAdminRole: true,
+      dealUsdtToCollector: LARGE_BRIDGE_AMOUNT,
+      dealNativeToBridge: 0
+    });
+    quotedFee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
+    vm.deal(address(arbitrumBridge), quotedFee);
+  }
+
+  function test_bridge_revertsIf_notOwnerOrGuardian() public {
+    address notOwner = makeAddr("not-owner");
+    vm.expectRevert(abi.encodeWithSelector(IWithGuardian.OnlyGuardianOrOwnerInvalidCaller.selector, notOwner));
+    vm.prank(notOwner);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, quotedFee);
+  }
+
+  function test_bridge_byGuardian_succeeds() public {
+    uint256 totalSupplyBefore = IERC20(OFTConstants.ARBITRUM_USDT).totalSupply();
+
+    vm.expectEmit(true, true, true, true, address(arbitrumBridge));
+    emit Bridge(
+      OFTConstants.ARBITRUM_USDT,
+      OFTConstants.ETHEREUM_EID,
+      address(AaveV3Ethereum.COLLECTOR),
+      LARGE_BRIDGE_AMOUNT,
+      LARGE_BRIDGE_AMOUNT
+    );
+
+    vm.prank(guardian);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, quotedFee);
+
+    assertEq(
+      IERC20(OFTConstants.ARBITRUM_USDT).totalSupply(),
+      totalSupplyBefore - LARGE_BRIDGE_AMOUNT,
+      "USDT should be burned"
+    );
+  }
+}
+
+/// @notice bridge() reverts inside ICollector.transfer when the steward lacks FUNDS_ADMIN.
+contract BridgeMissingRoleTest is OFTBridgeForkTestBase {
+  uint256 public quotedFee;
+
+  function setUp() public override {
+    _setUpArbitrumBridge({
+      grantFundsAdminRole: false,
+      dealUsdtToCollector: LARGE_BRIDGE_AMOUNT,
+      dealNativeToBridge: 0
+    });
+    quotedFee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
+    vm.deal(address(arbitrumBridge), quotedFee);
+  }
+
+  function test_bridge_revertsIf_noFundsAdminRole() public {
+    vm.expectRevert(ICollector.OnlyFundsAdmin.selector);
+    vm.prank(owner);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, quotedFee);
+  }
+}
+
+/// @notice Ownership lifecycle (Ownable from OZ via OwnableWithGuardian).
+contract TransferOwnershipTest is OFTBridgeForkTestBase {
+  function test_transferOwnership() public {
+    address newOwner = GovernanceV3Ethereum.EXECUTOR_LVL_1;
+
+    vm.prank(owner);
+    mainnetBridge.transferOwnership(newOwner);
+
+    assertEq(mainnetBridge.owner(), newOwner, "Ownership should be transferred");
+  }
+
+  function test_transferOwnership_revertsIf_notOwner() public {
+    address notOwner = makeAddr("not-owner");
+    address newOwner = makeAddr("new-owner");
+
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, notOwner));
+    vm.prank(notOwner);
+    mainnetBridge.transferOwnership(newOwner);
+  }
+
+  function test_renounceOwnership() public {
+    vm.prank(owner);
+    mainnetBridge.renounceOwnership();
+
+    assertEq(mainnetBridge.owner(), address(0), "Owner should be zero address");
+  }
+}
+
+/// @notice rescueEth access control: non-owner/guardian rejection and the guardian happy path.
+contract RescueEthAccessControlTest is OFTBridgeForkTestBase {
+  uint256 public constant ETH_AMOUNT = 5 ether;
+
+  function setUp() public override {
+    super.setUp();
+    vm.deal(address(mainnetBridge), ETH_AMOUNT);
+  }
+
+  function test_rescueEth_revertsIf_notOwnerOrGuardian() public {
+    address notOwner = makeAddr("not-owner");
+    vm.expectRevert(abi.encodeWithSelector(IWithGuardian.OnlyGuardianOrOwnerInvalidCaller.selector, notOwner));
+    vm.prank(notOwner);
+    mainnetBridge.rescueEth();
+  }
+
+  function test_rescueEth_byGuardian_succeeds() public {
+    uint256 collectorBalanceBefore = address(AaveV3Ethereum.COLLECTOR).balance;
+
+    vm.prank(guardian);
+    mainnetBridge.rescueEth();
+
+    assertEq(
+      address(AaveV3Ethereum.COLLECTOR).balance,
+      collectorBalanceBefore + ETH_AMOUNT,
+      "Collector should receive ETH"
+    );
+    assertEq(address(mainnetBridge).balance, 0, "Bridge should have 0 ETH balance");
+  }
+}
+
+/// @notice Funding paths for the LayerZero native fee: pre-fund vs. msg.value, and excess retention.
+contract BridgeNativeFeePathsTest is OFTBridgeForkTestBase {
+  uint256 public quotedFee;
+
+  function setUp() public override {
+    _setUpArbitrumBridge({
+      grantFundsAdminRole: true,
+      dealUsdtToCollector: LARGE_BRIDGE_AMOUNT,
+      dealNativeToBridge: 0
+    });
+    quotedFee = arbitrumBridge.quoteSendFee(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT);
+  }
+
+  function test_bridge_preFunded_zeroValue() public {
+    vm.deal(address(arbitrumBridge), quotedFee);
+
+    vm.prank(owner);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, quotedFee);
+
+    assertEq(address(arbitrumBridge).balance, 0, "Steward should have spent its native");
+  }
+
+  function test_bridge_msgValue_only() public {
+    vm.deal(owner, quotedFee);
+
+    vm.prank(owner);
+    arbitrumBridge.bridge{value: quotedFee}(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, quotedFee);
+
+    assertEq(address(arbitrumBridge).balance, 0, "Steward should have spent the msg.value");
+  }
+
+  function test_bridge_excessPreFunding_remainsOnSteward() public {
+    uint256 buffer = 1 ether;
+    vm.deal(address(arbitrumBridge), quotedFee + buffer);
+
+    vm.prank(owner);
+    arbitrumBridge.bridge(LARGE_BRIDGE_AMOUNT, LARGE_BRIDGE_AMOUNT, quotedFee);
+
+    assertEq(address(arbitrumBridge).balance, buffer, "Excess pre-funding should remain on steward");
   }
 }


### PR DESCRIPTION
Iteration based on https://github.com/aave-dao/aave-helpers/pull/666.

Changes (ordered by relevance):
- Contract is refactored to bridge only between L2s --> mainnet; destination EID is hardcoded
- Receiver is a hardcoded constant (mainnet collector)
- Extra checks added for `bridge`
- Interface adjusted for clarity; contract renamed to match the style from #7 